### PR TITLE
Alphabetically sort reported nodes in TextReporter

### DIFF
--- a/lib/Reporters/TextReporter.lua
+++ b/lib/Reporters/TextReporter.lua
@@ -17,6 +17,10 @@ local UNKNOWN_STATUS_SYMBOL = "?"
 
 local TextReporter = {}
 
+local function compareNodes(a, b)
+	return a.planNode.phrase < b.planNode.phrase
+end
+
 local function reportNode(node, buffer, level)
 	buffer = buffer or {}
 	level = level or 0
@@ -43,6 +47,7 @@ local function reportNode(node, buffer, level)
 	end
 
 	table.insert(buffer, line)
+	table.sort(node.children, compareNodes)
 
 	for _, child in ipairs(node.children) do
 		reportNode(child, buffer, level + 1)
@@ -53,6 +58,7 @@ end
 
 local function reportRoot(node)
 	local buffer = {}
+	table.sort(node.children, compareNodes)
 
 	for _, child in ipairs(node.children) do
 		reportNode(child, buffer, 0)


### PR DESCRIPTION
Closes #19. This will alphabetically (case-insensitively) sort test nodes in `TextReporter`; this should make it much easier to scan tests, since everything will always be in the same order.

This mutates test nodes because of `table.sort` - I'm unsure if this is something we're trying to avoid.