### PR TITLE
WIP: Add createSpy

### DIFF
--- a/lib/TestRunner.lua
+++ b/lib/TestRunner.lua
@@ -7,6 +7,7 @@
 ]]
 
 local Expectation = require(script.Parent.Expectation)
+local createSpy = require(script.Parent.createSpy)
 local TestEnum = require(script.Parent.TestEnum)
 local TestSession = require(script.Parent.TestSession)
 local Stack = require(script.Parent.Stack)
@@ -14,12 +15,11 @@ local Stack = require(script.Parent.Stack)
 local RUNNING_GLOBAL = "__TESTEZ_RUNNING_TEST__"
 
 local TestRunner = {
-	environment = {}
+	environment = {
+		expect = Expectation.new,
+		createSpy = createSpy,
+	}
 }
-
-function TestRunner.environment.expect(...)
-	return Expectation.new(...)
-end
 
 --[[
 	Runs the given TestPlan and returns a TestResults object representing the

--- a/lib/createSpy.lua
+++ b/lib/createSpy.lua
@@ -1,0 +1,52 @@
+local SpyStats = {}
+SpyStats.__index = SpyStats
+
+function SpyStats:assertCalledWith(...)
+	local len = select("#", ...)
+
+	assert(self.valuesLength, len, "length of expected values differs from stored values")
+
+	for i = 1, len do
+		local expected = select(i, ...)
+
+		assert(self.values[i] == expected, "value differs")
+	end
+end
+
+function SpyStats:captureValues(...)
+	local len = select("#", ...)
+	local result = {}
+
+	assert(self.valuesLength, len, "length of expected values differs from stored values")
+
+	for i = 1, len do
+		local key = select(i, ...)
+		result[key] = self.values[i]
+	end
+
+	return result
+end
+
+local function createSpy(inner)
+	local spyStats = {
+		callCount = 0,
+		values = {},
+		valuesLength = 0,
+	}
+
+	setmetatable(spyStats, SpyStats)
+
+	local function spyValue(...)
+		spyStats.callCount = spyStats.callCount + 1
+		spyStats.values = {...}
+		spyStats.valuesLength = select("#", ...)
+
+		if inner ~= nil then
+			return inner(...)
+		end
+	end
+
+	return spyValue, spyStats
+end
+
+return createSpy


### PR DESCRIPTION
This PR adds function spies. Because Lua doesn't support properties on functions, the method returns two different values, one containing the wrapped function and one containing a stats object that can be queried.

This is a modified form of something I worked on for Roact (new reconciler) and Otter, but would much rather have in TestEZ itself.

Before merge:
* [ ] Tests
* [ ] Documentation
* [ ] Changelog