### PR TITLE
Breaking change in TestBootstrap:run root argument

### DIFF
--- a/lib/TestBootstrap.lua
+++ b/lib/TestBootstrap.lua
@@ -40,14 +40,14 @@ function TestBootstrap:getModules(root, modules, current)
 	local function processChild(child, parent)
 		if isSpecScript(child) then
 			local method = require(child)
-			local path = getPath(child, root)
+			local path = getPath(child, parent)
 
 			table.insert(modules, {
 				method = method,
 				path = path
 			})
 		else
-			self:getModules(root, modules, child)
+			self:getModules(parent, modules, child)
 		end
 	end
 

--- a/lib/TestBootstrap.lua
+++ b/lib/TestBootstrap.lua
@@ -33,30 +33,13 @@ end
 --[[
 	Find all the ModuleScripts in this tree that are tests.
 ]]
-function TestBootstrap:getModules(root, modules, current)
+function TestBootstrap:getModules(root, modules)
 	modules = modules or {}
-	current = current or root
-
-	local function processChild(child, parent)
-		if isSpecScript(child) then
-			local method = require(child)
-			local path = getPath(child, parent)
-
-			table.insert(modules, {
-				method = method,
-				path = path
-			})
-		else
-			self:getModules(parent, modules, child)
-		end
-	end
 
 	if isSpecScript(root) then
-		processChild(root, root.Parent)
+		self:processScript(root, modules)
 	else
-		for _, child in ipairs(current:GetChildren()) do
-			processChild(child, root)
-		end
+		self:processFolder(root, modules)
 	end
 
 	table.sort(modules, function(a, b)
@@ -64,6 +47,28 @@ function TestBootstrap:getModules(root, modules, current)
 	end)
 
 	return modules
+end
+
+--[[
+	Recurse down into the processing
+]]
+function TestBootstrap:processFolder(folder, modules)
+	for _, child in ipairs(folder:GetChildren()) do
+		self:getModules(child, modules)
+	end
+end
+
+--[[
+	Collect tests from ModuleScript.
+]]
+function TestBootstrap:processScript(child, modules)
+	local method = require(child)
+	local path = getPath(child, child.Parent)
+
+	table.insert(modules, {
+		method = method,
+		path = path
+	})
 end
 
 --[[

--- a/lib/TestBootstrap.lua
+++ b/lib/TestBootstrap.lua
@@ -22,6 +22,7 @@ local function getPath(module, root)
 		table.insert(path, stripSpecSuffix(last.Name))
 		last = last.Parent
 	end
+	table.insert(path, stripSpecSuffix(root.Name))
 
 	return path
 end
@@ -82,6 +83,10 @@ function TestBootstrap:run(root, reporter, showTimingInfo, noXpcallByDefault)
 	local modules
 	if type(root) == "function" then
 		modules = {{method = root, path = {}}}
+	elseif type(root) == "table" then
+		for _, subRoot in ipairs(root) do
+			modules = self:getModules(subRoot, modules)
+		end
 	else
 		modules = self:getModules(root)
 	end

--- a/lib/TestBootstrap.lua
+++ b/lib/TestBootstrap.lua
@@ -11,6 +11,9 @@ local TestBootstrap = {}
 local function stripSpecSuffix(name)
 	return (name:gsub("%.spec$", ""))
 end
+local function isSpecScript(aScript)
+	return aScript:IsA("ModuleScript") and aScript.Name:match("%.spec$")
+end
 
 local function getPath(module, root)
 	root = root or game
@@ -34,8 +37,8 @@ function TestBootstrap:getModules(root, modules, current)
 	modules = modules or {}
 	current = current or root
 
-	for _, child in ipairs(current:GetChildren()) do
-		if child:IsA("ModuleScript") and child.Name:match("%.spec$") then
+	local function processChild(child, parent)
+		if isSpecScript(child) then
 			local method = require(child)
 			local path = getPath(child, root)
 
@@ -45,6 +48,14 @@ function TestBootstrap:getModules(root, modules, current)
 			})
 		else
 			self:getModules(root, modules, child)
+		end
+	end
+
+	if isSpecScript(root) then
+		processChild(root, root.Parent)
+	else
+		for _, child in ipairs(current:GetChildren()) do
+			processChild(child, root)
 		end
 	end
 

--- a/lib/TestBootstrap.lua
+++ b/lib/TestBootstrap.lua
@@ -37,7 +37,7 @@ function TestBootstrap:getModules(root, modules)
 	modules = modules or {}
 
 	if isSpecScript(root) then
-		self:processScript(root, modules)
+		self.processScript(root, modules)
 	else
 		self:processFolder(root, modules)
 	end
@@ -61,7 +61,7 @@ end
 --[[
 	Collect tests from ModuleScript.
 ]]
-function TestBootstrap:processScript(child, modules)
+function TestBootstrap.processScript(child, modules)
 	local method = require(child)
 	local path = getPath(child, child.Parent)
 

--- a/lib/TestBootstrap.lua
+++ b/lib/TestBootstrap.lua
@@ -100,10 +100,6 @@ function TestBootstrap:run(roots, reporter, otherOptions)
 	local modules
 	for _, subRoot in ipairs(roots) do
 		modules = self:getModules(subRoot, modules)
-	elseif type(root) == "table" then
-		for _, subRoot in ipairs(root) do
-			modules = self:getModules(subRoot, modules)
-		end
 	end
 
 	local afterModules = tick()

--- a/lib/TestBootstrap.lua
+++ b/lib/TestBootstrap.lua
@@ -81,7 +81,7 @@ end
 	the test plan before we execute it, allowing them to toggle specific tests
 	before they're run, but after they've been identified!
 ]]
-function TestBootstrap:run(root, reporter, otherOptions)
+function TestBootstrap:run(roots, reporter, otherOptions)
 	reporter = reporter or TextReporter
 
 	otherOptions = otherOptions or {}
@@ -89,21 +89,21 @@ function TestBootstrap:run(root, reporter, otherOptions)
 	local noXpcallByDefault = otherOptions["noXpcallByDefault"] or false
 	local testNamePattern = otherOptions["testNamePattern"]
 
-	if not root then
-		error("You must provide a root object to search for tests in!", 2)
+	if not roots then
+		error("You must provide a roots object to search for tests in!", 2)
+	elseif type(roots) ~= "table" then
+		error("roots object should be a table!", 3)
 	end
 
 	local startTime = tick()
 
 	local modules
-	if type(root) == "function" then
-		modules = {{method = root, path = {}}}
+	for _, subRoot in ipairs(roots) do
+		modules = self:getModules(subRoot, modules)
 	elseif type(root) == "table" then
 		for _, subRoot in ipairs(root) do
 			modules = self:getModules(subRoot, modules)
 		end
-	else
-		modules = self:getModules(root)
 	end
 
 	local afterModules = tick()

--- a/lib/TestBootstrap.lua
+++ b/lib/TestBootstrap.lua
@@ -33,12 +33,13 @@ end
 --[[
 	Find all the ModuleScripts in this tree that are tests.
 ]]
-function TestBootstrap:getModules(root, modules)
+function TestBootstrap:getModules(root, modules, current)
 	modules = modules or {}
+	current = current or root
 
-	if isSpecScript(root) then
-		local method = require(root)
-		local path = getPath(root, root.Parent)
+	if isSpecScript(current) then
+		local method = require(current)
+		local path = getPath(current, root)
 
 		table.insert(modules, {
 			method = method,
@@ -46,8 +47,8 @@ function TestBootstrap:getModules(root, modules)
 		})
 	end
 
-	for _, child in ipairs(root:GetChildren()) do
-		self:getModules(child, modules)
+	for _, child in ipairs(current:GetChildren()) do
+		self:getModules(root, modules, child)
 	end
 
 	table.sort(modules, function(a, b)


### PR DESCRIPTION
REMOVED:
1. spec function as root argument
1. single root folder as root argument

ADDED:
1. Roots argument requires array of roots now
1. Allow single spec module script as an element in the roots argument

