### PR TITLE
Feature/itFIXME

### DIFF
--- a/lib/TestPlan.lua
+++ b/lib/TestPlan.lua
@@ -59,7 +59,7 @@ function TestPlan.createNode(phrase, nodeType, nodeModifier)
 		modifier = nodeModifier,
 		children = {},
 		callback = nil,
-		fullName = constructNodeFullName
+		getFullName = constructNodeFullName
 	}
 
 	return node

--- a/lib/TestPlan.lua
+++ b/lib/TestPlan.lua
@@ -37,6 +37,16 @@ function TestPlan:visitAllNodes(callback, root)
 	end
 end
 
+local function constructNodeFullName(node)
+	if node.parent then
+		local parentPhrase = constructNodeFullName(node.parent)
+		if parentPhrase then
+			return parentPhrase .. " " .. node.phrase
+		end
+	end
+	return node.phrase
+end
+
 --[[
 	Creates a new node that would be suitable to insert into the TestPlan.
 ]]
@@ -48,7 +58,8 @@ function TestPlan.createNode(phrase, nodeType, nodeModifier)
 		type = nodeType,
 		modifier = nodeModifier,
 		children = {},
-		callback = nil
+		callback = nil,
+		fullName = constructNodeFullName
 	}
 
 	return node

--- a/lib/TestPlanBuilder.lua
+++ b/lib/TestPlanBuilder.lua
@@ -88,6 +88,8 @@ function TestPlanBuilder:pushNode(phrase, nodeType, nodeModifier)
 		local fullName = constructFullName(useNode)
 		if fullName:match(self.testNamePattern) then
 			useNode.modifier = TestEnum.NodeModifier.Focus
+		else
+			useNode.modifier = TestEnum.NodeModifier.Skip
 		end
 	end
 	useNode.HACK_NO_XPCALL = self.noXpcallByDefault

--- a/lib/TestPlanBuilder.lua
+++ b/lib/TestPlanBuilder.lua
@@ -75,7 +75,7 @@ function TestPlanBuilder:pushNode(phrase, nodeType, nodeModifier)
 
 	local nodeModifierNotSet = useNode.modifier == nil or useNode.modifier == TestEnum.NodeModifier.None
 	if self.testNamePattern and nodeModifierNotSet then
-		local fullName = useNode:fullName()
+		local fullName = useNode:getFullName()
 		if fullName:match(self.testNamePattern) then
 			useNode.modifier = TestEnum.NodeModifier.Focus
 		else

--- a/lib/TestPlanBuilder.lua
+++ b/lib/TestPlanBuilder.lua
@@ -48,16 +48,6 @@ function TestPlanBuilder:getCurrentNode()
 	return self.nodeStack[#self.nodeStack] or self.plan
 end
 
-local function constructFullName(node)
-	if node.parent then
-		local parentPhrase = constructFullName(node.parent)
-		if parentPhrase then
-			return parentPhrase .. " " .. node.phrase
-		end
-	end
-	return node.phrase
-end
-
 --[[
 	Creates and pushes a node onto the navigation stack.
 ]]
@@ -85,7 +75,7 @@ function TestPlanBuilder:pushNode(phrase, nodeType, nodeModifier)
 
 	local nodeModifierNotSet = useNode.modifier == nil or useNode.modifier == TestEnum.NodeModifier.None
 	if self.testNamePattern and nodeModifierNotSet then
-		local fullName = constructFullName(useNode)
+		local fullName = useNode:fullName()
 		if fullName:match(self.testNamePattern) then
 			useNode.modifier = TestEnum.NodeModifier.Focus
 		else

--- a/lib/TestPlanner.lua
+++ b/lib/TestPlanner.lua
@@ -110,6 +110,22 @@ function TestPlanner.createEnvironment(builder)
 		builder:popNode()
 	end
 
+	function env.itFIXME(phrase, callback)
+		local node = builder:pushNode(phrase, TestEnum.NodeType.It, TestEnum.NodeModifier.Skip)
+
+		warn("FIXME: broken test", node:fullName())
+		node.callback = callback
+
+		builder:popNode()
+	end
+
+	function env.FIXME(optionalMessage)
+		local currentNode = builder:getCurrentNode()
+		warn("FIXME: broken test", currentNode:fullName(), optionalMessage or "")
+
+		currentNode.modifier = TestEnum.NodeModifier.Skip
+	end
+
 	function env.FOCUS()
 		local currentNode = builder:getCurrentNode()
 

--- a/lib/TestPlanner.lua
+++ b/lib/TestPlanner.lua
@@ -113,7 +113,7 @@ function TestPlanner.createEnvironment(builder)
 	function env.itFIXME(phrase, callback)
 		local node = builder:pushNode(phrase, TestEnum.NodeType.It, TestEnum.NodeModifier.Skip)
 
-		warn("FIXME: broken test", node:fullName())
+		warn("FIXME: broken test", node:getFullName())
 		node.callback = callback
 
 		builder:popNode()
@@ -121,7 +121,7 @@ function TestPlanner.createEnvironment(builder)
 
 	function env.FIXME(optionalMessage)
 		local currentNode = builder:getCurrentNode()
-		warn("FIXME: broken test", currentNode:fullName(), optionalMessage or "")
+		warn("FIXME: broken test", currentNode:getFullName(), optionalMessage or "")
 
 		currentNode.modifier = TestEnum.NodeModifier.Skip
 	end


### PR DESCRIPTION
Introduce itFIXME and FIXME modifiers that will produce `FIXME: broken test <full test name>` warning when planned

Execution of FIXME tests/groups will be skipped
