### PR TITLE
Add TextReporterQuiet, a workaround for CI systems

### DIFF
--- a/lib/Reporters/TextReporterQuiet.lua
+++ b/lib/Reporters/TextReporterQuiet.lua
@@ -17,7 +17,7 @@ local STATUS_SYMBOLS = {
 }
 local UNKNOWN_STATUS_SYMBOL = "?"
 
-local TextReporter = {}
+local TextReporterQuiet = {}
 
 local function reportNode(node, buffer, level)
 	buffer = buffer or {}
@@ -64,7 +64,7 @@ local function report(root)
 	return table.concat(buffer, "\n")
 end
 
-function TextReporter.report(results)
+function TextReporterQuiet.report(results)
 	local resultBuffer = {
 		"Test results:",
 		report(results),
@@ -94,4 +94,4 @@ function TextReporter.report(results)
 	end
 end
 
-return TextReporter
+return TextReporterQuiet

--- a/lib/Reporters/TextReporterQuiet.lua
+++ b/lib/Reporters/TextReporterQuiet.lua
@@ -29,17 +29,12 @@ local function reportNode(node, buffer, level)
 
 	local line
 
-	if node.status ~= nil and node.status ~= TestEnum.TestStatus.Success then
+	if node.status ~= TestEnum.TestStatus.Success then
 		local symbol = STATUS_SYMBOLS[node.status] or UNKNOWN_STATUS_SYMBOL
 
 		line = ("%s[%s] %s"):format(
 			INDENT:rep(level),
 			symbol,
-			node.planNode.phrase
-		)
-	else
-		line = ("%s%s"):format(
-			INDENT:rep(level),
 			node.planNode.phrase
 		)
 	end

--- a/lib/Reporters/TextReporterQuiet.lua
+++ b/lib/Reporters/TextReporterQuiet.lua
@@ -1,0 +1,102 @@
+--[[
+	Copy of TextReporter that doesn't output successful tests.
+
+	This should be temporary, it's just a workaround to make CI environments
+	happy in the short-term.
+]]
+
+local TestService = game:GetService("TestService")
+
+local TestEnum = require(script.Parent.Parent.TestEnum)
+
+local INDENT = (" "):rep(3)
+local STATUS_SYMBOLS = {
+	[TestEnum.TestStatus.Success] = "+",
+	[TestEnum.TestStatus.Failure] = "-",
+	[TestEnum.TestStatus.Skipped] = "~"
+}
+local UNKNOWN_STATUS_SYMBOL = "?"
+
+local TextReporter = {}
+
+local function reportNode(node, buffer, level)
+	buffer = buffer or {}
+	level = level or 0
+
+	if node.status == TestEnum.TestStatus.Skipped then
+		return buffer
+	end
+
+	local line
+
+	if node.status ~= nil and node.status ~= TestEnum.TestStatus.Success then
+		local symbol = STATUS_SYMBOLS[node.status] or UNKNOWN_STATUS_SYMBOL
+
+		line = ("%s[%s] %s"):format(
+			INDENT:rep(level),
+			symbol,
+			node.planNode.phrase
+		)
+	else
+		line = ("%s%s"):format(
+			INDENT:rep(level),
+			node.planNode.phrase
+		)
+	end
+
+	table.insert(buffer, line)
+
+	for _, child in ipairs(node.children) do
+		reportNode(child, buffer, level + 1)
+	end
+
+	return buffer
+end
+
+local function reportRoot(node)
+	local buffer = {}
+
+	for _, child in ipairs(node.children) do
+		reportNode(child, buffer, 0)
+	end
+
+	return buffer
+end
+
+local function report(root)
+	local buffer = reportRoot(root)
+
+	return table.concat(buffer, "\n")
+end
+
+function TextReporter.report(results)
+	local resultBuffer = {
+		"Test results:",
+		report(results),
+		("%d passed, %d failed, %d skipped"):format(
+			results.successCount,
+			results.failureCount,
+			results.skippedCount
+		)
+	}
+
+	print(table.concat(resultBuffer, "\n"))
+
+	if results.failureCount > 0 then
+		print(("%d test nodes reported failures."):format(results.failureCount))
+	end
+
+	if #results.errors > 0 then
+		print("Errors reported by tests:")
+		print("")
+
+		for _, message in ipairs(results.errors) do
+			TestService:Error(message)
+
+			-- Insert a blank line after each error
+			print("")
+		end
+	end
+end
+
+return TextReporter

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -8,6 +8,7 @@ local TestResults = require(script.TestResults)
 local TestRunner = require(script.TestRunner)
 local TestSession = require(script.TestSession)
 local TextReporter = require(script.Reporters.TextReporter)
+local TextReporterQuiet = require(script.Reporters.TextReporterQuiet)
 local TeamCityReporter = require(script.Reporters.TeamCityReporter)
 
 local function run(testRoot, callback)
@@ -33,6 +34,7 @@ local TestEZ = {
 
 	Reporters = {
 		TextReporter = TextReporter,
+		TextReporterQuiet = TextReporterQuiet,
 		TeamCityReporter = TeamCityReporter,
 	},
 }


### PR DESCRIPTION
`TextReporter` spews a lot of noise into logs, which has been causing problems internally.

Long-term, we need to rearchitect TestEZ significantly, but in the short term, having a different text reporter that's quieter seems like a good idea.