### PR TITLE
Fix throw expectation error message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ install:
   - luarocks install luacheck
 
 script:
-  - luacheck lib
+  - luacheck lib tests
   - lua spec.lua

--- a/lib/Expectation.lua
+++ b/lib/Expectation.lua
@@ -237,10 +237,10 @@ function Expectation:throw()
 	local result = ok ~= self.successCondition
 
 	local message = formatMessage(self.successCondition,
+		"Expected function to throw an error, but it did not.",
 		("Expected function to succeed, but it threw an error: %s"):format(
 			tostring(err)
-		),
-		"Expected function to throw an error, but it did not."
+		)
 	)
 
 	assertLevel(result, message, 3)

--- a/lib/Expectation.spec.lua
+++ b/lib/Expectation.spec.lua
@@ -1,69 +1,64 @@
 local Expectation = require(script.Parent.Expectation)
 
-local tests = {}
+return {
+    ["it should succeed if an empty function is expected to never throw"] = function()
+        local function shouldNotThrow()
+            return
+        end
 
-tests["it should succeed if an empty function is expected to never throw"] = function()
-    local function shouldNotThrow()
-        return
-    end
+        local expect = Expectation.new(shouldNotThrow)
 
-    local expect = Expectation.new(shouldNotThrow)
+        local success = pcall(function()
+            expect.never:throw()
+        end)
 
-    local success = pcall(function()
-        expect.never:throw()
-    end)
+        assert(success, "should succeed")
+    end,
+    ["it should succeed if a throwing function is expected to throw"] = function()
+        local function shouldThrow()
+            error("oof")
+        end
 
-    assert(success, "should succeed")
-end
+        local expect = Expectation.new(shouldThrow)
 
-tests["it should succeed if a throwing function is expected to throw"] = function()
-    local function shouldThrow()
-        error("oof")
-    end
+        local success = pcall(function()
+            expect:throw()
+        end)
 
-    local expect = Expectation.new(shouldThrow)
+        assert(success, "should succeed")
+    end,
+    ["it should fail if a throwing function is expected to never throw"] = function()
+        local function shouldThrow()
+            error("oof")
+        end
 
-    local success = pcall(function()
-        expect:throw()
-    end)
+        local expect = Expectation.new(shouldThrow)
 
-    assert(success, "should succeed")
-end
+        local success, message = pcall(function()
+            expect.never:throw()
+        end)
 
-tests["it should fail if a throwing function is expected to never throw"] = function()
-    local function shouldThrow()
-        error("oof")
-    end
+        assert(not success, "should fail")
+        assert(
+            message:match("Expected function to succeed, but it threw an error:"),
+            ("Error message does not match:\n%s\n"):format(message)
+        )
+    end,
+    ["it should fail if an empty function is expected to throw"] = function()
+        local function shouldNotThrow()
+            return
+        end
 
-    local expect = Expectation.new(shouldThrow)
+        local expect = Expectation.new(shouldNotThrow)
 
-    local success, message = pcall(function()
-        expect.never:throw()
-    end)
+        local success, message = pcall(function()
+            expect:throw()
+        end)
 
-    assert(not success, "should fail")
-    assert(
-        message:match("Expected function to succeed, but it threw an error:"),
-        ("Error message does not match:\n%s\n"):format(message)
-    )
-end
-
-tests["it should fail if an empty function is expected to throw"] = function()
-    local function shouldNotThrow()
-        return
-    end
-
-    local expect = Expectation.new(shouldNotThrow)
-
-    local success, message = pcall(function()
-        expect:throw()
-    end)
-
-    assert(not success, "should fail")
-    assert(
-        message:match("Expected function to throw an error, but it did not."),
-        ("Error message does not match:\n%s\n"):format(message)
-    )
-end
-
-return tests
+        assert(not success, "should fail")
+        assert(
+            message:match("Expected function to throw an error, but it did not."),
+            ("Error message does not match:\n%s\n"):format(message)
+        )
+    end,
+}

--- a/lib/Expectation.spec.lua
+++ b/lib/Expectation.spec.lua
@@ -1,0 +1,69 @@
+local Expectation = require(script.Parent.Expectation)
+
+local tests = {}
+
+tests["it should succeed if an empty function is expected to never throw"] = function()
+    local function shouldNotThrow()
+        return
+    end
+
+    local expect = Expectation.new(shouldNotThrow)
+
+    local success = pcall(function()
+        expect.never:throw()
+    end)
+
+    assert(success, "should succeed")
+end
+
+tests["it should succeed if a throwing function is expected to throw"] = function()
+    local function shouldThrow()
+        error("oof")
+    end
+
+    local expect = Expectation.new(shouldThrow)
+
+    local success = pcall(function()
+        expect:throw()
+    end)
+
+    assert(success, "should succeed")
+end
+
+tests["it should fail if a throwing function is expected to never throw"] = function()
+    local function shouldThrow()
+        error("oof")
+    end
+
+    local expect = Expectation.new(shouldThrow)
+
+    local success, message = pcall(function()
+        expect.never:throw()
+    end)
+
+    assert(not success, "should fail")
+    assert(
+        message:match("Expected function to succeed, but it threw an error:"),
+        ("Error message does not match:\n%s\n"):format(message)
+    )
+end
+
+tests["it should fail if an empty function is expected to throw"] = function()
+    local function shouldNotThrow()
+        return
+    end
+
+    local expect = Expectation.new(shouldNotThrow)
+
+    local success, message = pcall(function()
+        expect:throw()
+    end)
+
+    assert(not success, "should fail")
+    assert(
+        message:match("Expected function to throw an error, but it did not."),
+        ("Error message does not match:\n%s\n"):format(message)
+    )
+end
+
+return tests

--- a/spec.lua
+++ b/spec.lua
@@ -96,7 +96,7 @@ for _, testModule in ipairs(unitTests) do
 			successCount = successCount + 1
 		else
 			failureCount = failureCount + 1
-			table.insert(errorMessages, message)
+			table.insert(errorMessages, ("Test: %s\nError: %s"):format(name, message))
 		end
 	end
 end

--- a/spec.lua
+++ b/spec.lua
@@ -54,20 +54,6 @@ local function findUnitTests(container, foundTests)
 	foundTests = foundTests or {}
 
 	for _, child in ipairs(container:GetChildren()) do
-		if child.Name:match("%.spec$") then
-			table.insert(foundTests, child)
-		end
-
-		findUnitTests(child, foundTests)
-	end
-
-	return foundTests
-end
-
-local function findIntegrationTests(container, foundTests)
-	foundTests = foundTests or {}
-
-	for _, child in ipairs(container:GetChildren()) do
 		if child:IsA("ModuleScript") then
 			table.insert(foundTests, child)
 		end
@@ -79,7 +65,7 @@ local function findIntegrationTests(container, foundTests)
 end
 
 -- Run all unit tests, which are located in .spec.lua files next to the source
-local unitTests = findUnitTests(root.TestEZ)
+local unitTests = findUnitTests(root.TestEZTests)
 print("Running unit tests...")
 local failureCount = 0
 local successCount = 0
@@ -87,6 +73,7 @@ local errorMessages = {}
 
 -- Unit tests are expected to load individual files relative to themselves
 for _, testModule in ipairs(unitTests) do
+	print('loading', testModule)
 	local tests = habitat:require(testModule)
 
 	for name, testFunction in pairs(tests) do
@@ -105,15 +92,6 @@ print(("Unit tests: %d passed, %d failed\n"):format(successCount, failureCount))
 if failureCount > 0 then
 	print(table.concat(errorMessages, "\n\n"))
 	os.exit(1)
-end
-
--- Run all integration tests, which are located in the 'tests' folder
-local integrationTests = findIntegrationTests(root.TestEZTests)
-print(("Running %d integration tests..."):format(#integrationTests))
-
--- Integration tests should be passed the root TestEZ object
-for _, test in ipairs(integrationTests) do
-	habitat:require(test)(habitat:require(root.TestEZ))
 end
 
 print("All tests passed.")

--- a/spec.lua
+++ b/spec.lua
@@ -80,11 +80,31 @@ end
 
 -- Run all unit tests, which are located in .spec.lua files next to the source
 local unitTests = findUnitTests(root.TestEZ)
-print(("Running %d unit tests..."):format(#unitTests))
+print("Running unit tests...")
+local failureCount = 0
+local successCount = 0
+local errorMessages = {}
 
 -- Unit tests are expected to load individual files relative to themselves
-for _, test in ipairs(unitTests) do
-	habitat:require(test)()
+for _, testModule in ipairs(unitTests) do
+	local tests = habitat:require(testModule)
+
+	for name, testFunction in pairs(tests) do
+		local success, message = pcall(testFunction)
+
+		if success then
+			successCount = successCount + 1
+		else
+			failureCount = failureCount + 1
+			table.insert(errorMessages, message)
+		end
+	end
+end
+
+print(("Unit tests: %d passed, %d failed\n"):format(successCount, failureCount))
+if failureCount > 0 then
+	print(table.concat(errorMessages, "\n\n"))
+	os.exit(1)
 end
 
 -- Run all integration tests, which are located in the 'tests' folder

--- a/spec.lua
+++ b/spec.lua
@@ -73,7 +73,6 @@ local errorMessages = {}
 
 -- Unit tests are expected to load individual files relative to themselves
 for _, testModule in ipairs(unitTests) do
-	print('loading', testModule)
 	local tests = habitat:require(testModule)
 
 	for name, testFunction in pairs(tests) do

--- a/tests/Expectation.lua
+++ b/tests/Expectation.lua
@@ -4,7 +4,6 @@ local Expectation = require(TestEZ.Expectation)
 return {
     ["it should succeed if an empty function is expected to never throw"] = function()
         local function shouldNotThrow()
-            return
         end
 
         local expect = Expectation.new(shouldNotThrow)
@@ -47,7 +46,6 @@ return {
     end,
     ["it should fail if an empty function is expected to throw"] = function()
         local function shouldNotThrow()
-            return
         end
 
         local expect = Expectation.new(shouldNotThrow)

--- a/tests/Expectation.lua
+++ b/tests/Expectation.lua
@@ -1,4 +1,5 @@
-local Expectation = require(script.Parent.Expectation)
+local TestEZ = script.Parent.Parent.TestEZ
+local Expectation = require(TestEZ.Expectation)
 
 return {
     ["it should succeed if an empty function is expected to never throw"] = function()

--- a/tests/api.lua
+++ b/tests/api.lua
@@ -1,4 +1,8 @@
-return function(TestEZ)
-	assert(typeof(TestEZ) == "table")
-	assert(typeof(TestEZ.run) == "function")
-end
+local TestEZ = require(script.Parent.Parent.TestEZ)
+
+return {
+	function()
+		assert(typeof(TestEZ) == "table")
+		assert(typeof(TestEZ.run) == "function")
+	end,
+}


### PR DESCRIPTION
Closes #36 

I also added a way to write unit tests. Before it would expect to run only one function for each file, but I think it would be preferable to have multiple tests per file. So now it expects a table that maps test case names with a function.