### PR TITLE
Revert "Throw error when expect receive multiple arguments (#49)"

### DIFF
--- a/lib/Expectation.lua
+++ b/lib/Expectation.lua
@@ -72,9 +72,7 @@ end
 --[[
 	Create a new expectation
 ]]
-function Expectation.new(value, ...)
-	assert(select("#", ...) == 0, "expect takes only a single argument")
-
+function Expectation.new(value)
 	local self = {
 		value = value,
 		successCondition = true,

--- a/tests/Expectation.lua
+++ b/tests/Expectation.lua
@@ -2,13 +2,6 @@ local TestEZ = script.Parent.Parent.TestEZ
 local Expectation = require(TestEZ.Expectation)
 
 return {
-    ["it should fail if expect is given more than one argument"] = function()
-        local success = pcall(function()
-            Expectation.new(true, true)
-        end)
-
-        assert(not success, "should fail")
-    end,
     ["it should succeed if an empty function is expected to never throw"] = function()
         local function shouldNotThrow()
         end


### PR DESCRIPTION
This reverts #49, which we need to upgrade TestEZ internally.

We should revisit this idea with a more holistic approach at a later time.