### PR TITLE
Fix multiple roots causing some test modules to be ignored

### DIFF
--- a/lib/TestBootstrap.lua
+++ b/lib/TestBootstrap.lua
@@ -95,9 +95,13 @@ function TestBootstrap:run(roots, reporter, otherOptions)
 
 	local startTime = tick()
 
-	local modules
+	local modules = {}
 	for _, subRoot in ipairs(roots) do
-		modules = self:getModules(subRoot, modules)
+		local newModules = self:getModules(subRoot)
+
+		for _, newModule in ipairs(newModules) do
+			table.insert(modules, newModule)
+		end
 	end
 
 	local afterModules = tick()


### PR DESCRIPTION
The fix introduced by #54 caused a regression internally that caused 2,000 of our tests to not run at all. We didn't catch this with the initial deployment. This change fixes the regressions from that work.

Writing a test for this in the confines of TestEZ isn't feasible right now since we can't set up `ModuleScript` instances due to permission restrictions. We also don't have the infrastructure for fabricating testing scenarios in the framework right now. I'm verifying this change manually by monitoring test case counts after deploying this change internally.