### PR TITLE
Add Expectation.extend for custom matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,12 @@ TestEZ.Expectation.extend({
 		if pass then
 			return {
 				pass = true,
-				message = ("Expected %s not to be divisible by %s"):format(receivedValue, expectedValue)
+				message = ("Expected %s to be divisible by %s"):format(receivedValue, expectedValue)
 			}
 		else
 			return {
 				pass = false,
-				message = ("Expected %s to be divisible by %s"):format(receivedValue, expectedValue)
+				message = ("Expected %s not to be divisible by %s"):format(receivedValue, expectedValue)
 			}
 		end
 	end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,35 @@
 # TestEZ Changelog
 
 ## Current master
+* Added `Expectation.extend` which allow projects to add their own matchers to TestEZ.
+  * Matchers are functions that should return an object with with two keys, boolean `pass` and a string `message`
+
+```lua
+-- setting up test runners
+local TestEZ = require(ReplicatedStorage.Packages.Dev.TestEZ)
+
+TestEZ.Expectation.extend({
+	divisibleBy = function(receivedValue, expectedValue)
+		local pass = receivedValue % expectedValue == 0
+		if pass then
+			return {
+				pass = true,
+				message = ("Expected %s not to be divisible by %s"):format(receivedValue, expectedValue)
+			}
+		else
+			return {
+				pass = false,
+				message = ("Expected %s to be divisible by %s"):format(receivedValue, expectedValue)
+			}
+		end
+	end
+})
+
+-- spec.lua
+it("should be an even number", function()
+	expect(10).to.be.divisibleBy(2)
+end)
+```
 
 ## 0.1.1 (2020-01-23)
 * Added beforeAll, beforeEach, afterEach, afterAll lifecycle hooks for testing

--- a/src/Expectation.lua
+++ b/src/Expectation.lua
@@ -249,4 +249,17 @@ function Expectation:throw()
 	return self
 end
 
+function Expectation.extend(matchers, a, b)
+	for name, implementation in pairs(matchers) do
+		Expectation[name] = function(self, ...)
+			local result = implementation(self.value, ...)
+			local pass = result.pass == self.successCondition
+
+			assertLevel(pass, result.message, 3)
+			self:_resetModifiers()
+			return self
+		end
+	end
+end
+
 return Expectation

--- a/src/Expectation.lua
+++ b/src/Expectation.lua
@@ -249,7 +249,7 @@ function Expectation:throw()
 	return self
 end
 
-function Expectation.extend(matchers, a, b)
+function Expectation.extend(matchers)
 	for name, implementation in pairs(matchers) do
 		Expectation[name] = function(self, ...)
 			local result = implementation(self.value, ...)

--- a/src/Expectation.lua
+++ b/src/Expectation.lua
@@ -16,6 +16,7 @@
 ]]
 
 local Expectation = {}
+local extensions = {}
 
 --[[
 	These keys don't do anything except make expectations read more cleanly
@@ -103,6 +104,10 @@ function Expectation.__index(self, key)
 		newExpectation.successCondition = not self.successCondition
 
 		return newExpectation
+	end
+
+	if extensions[key] then
+		return bindSelf(self, extensions[key])
 	end
 
 	-- Fall back to methods provided by Expectation
@@ -251,7 +256,7 @@ end
 
 function Expectation.extend(matchers)
 	for name, implementation in pairs(matchers) do
-		Expectation[name] = function(self, ...)
+		extensions[name] = function(self, ...)
 			local result = implementation(self.value, ...)
 			local pass = result.pass == self.successCondition
 

--- a/tests/Expectation.lua
+++ b/tests/Expectation.lua
@@ -80,12 +80,12 @@ return {
 
         do
             -- foo match (normal)
-            local success = pcall(function()
+            local success, message = pcall(function()
                 local expect = Expectation.new(100)
                 return expect:foo(100)
             end)
 
-            assert(success == true, "foo should not fail if the values are the same")
+            assert(success == true, "foo should not fail if the values are the same. " .. tostring(message))
         end
 
         do

--- a/tests/Expectation.lua
+++ b/tests/Expectation.lua
@@ -60,4 +60,76 @@ return {
             ("Error message does not match:\n%s\n"):format(message)
         )
     end,
+    ["it should allow for custom expectations using extend"] = function()
+        Expectation.extend({
+            foo = function(received, expected)
+                local pass = received == expected
+                if pass then
+                    return {
+                        message = string.format("custom failure message (not)"),
+                        pass = true,
+                    }
+                else
+                    return {
+                        message = string.format("custom failure message"),
+                        pass = false,
+                    }
+                end
+            end,
+        })
+
+        do
+            -- foo match (normal)
+            local success = pcall(function()
+                local expect = Expectation.new(100)
+                return expect:foo(100)
+            end)
+
+            assert(success == true, "foo should not fail if the values are the same")
+        end
+
+        do
+            -- foo mis-match (normal)
+            local success, value = pcall(function()
+                local expect = Expectation.new(100)
+                return expect:foo(200)
+            end)
+
+            assert(success == false, "foo should fail if the values are not the same")
+            assert(value == "custom failure message", "should allow for custom failure message")
+        end
+
+        do
+            -- foo match (never)
+            local success, value = pcall(function()
+                local expect = Expectation.new(100)
+                return expect.never:foo(100)
+            end)
+
+            assert(success == false, "should fail if matching and inverse with never")
+            assert(value == "custom failure message (not)", "should allow for custom failure message (not)")
+        end
+
+        do
+            -- foo mis-match (never)
+            local success = pcall(function()
+                local expect = Expectation.new(100)
+                return expect.never:foo(200)
+            end)
+
+            assert(success == true, "should not fail if mis-matching and inverse with never")
+        end
+
+        do
+            -- both
+            local success = pcall(function()
+                local expect = Expectation.new(100)
+                return expect
+                    .never:foo(200)
+                    :foo(100)
+            end)
+
+            assert(success == true, "should use the last expectation")
+        end
+    end,
 }

--- a/tests/Expectation.lua
+++ b/tests/Expectation.lua
@@ -131,5 +131,41 @@ return {
 
             assert(success == true, "should use the last expectation")
         end
+
+        -- test subsequent extends
+        Expectation.extend({
+            bar = function(received)
+                local pass = received == "bar"
+                if pass then
+                    return {
+                        pass = true,
+                        message = "Expected anything but bar"
+                    }
+                else
+                    return {
+                        pass = false,
+                        message = "Expected bar",
+                    }
+                end
+            end,
+        })
+
+        do
+            local success = pcall(function()
+                local expect = Expectation.new("bar")
+                return expect:bar()
+            end)
+
+            assert(success == true, "should add new matcher on second extend call")
+        end
+
+        do
+            local success = pcall(function()
+                local expect = Expectation.new(0)
+                return expect:foo(0)
+            end)
+
+            assert(success == true, "should not overwrite previous extend call")
+        end
     end,
 }


### PR DESCRIPTION
* Added `Expectation.extend` which allow projects to add their own matchers to TestEZ.
  * Matchers are functions that should return an object with with two keys, boolean `pass` and a string `message`

```lua
-- setting up test runners
local TestEZ = require(ReplicatedStorage.Packages.Dev.TestEZ)

TestEZ.Expectation.extend({
	divisibleBy = function(receivedValue, expectedValue)
		local pass = receivedValue % expectedValue == 0
		if pass then
			return {
				pass = true,
				message = ("Expected %s to be divisible by %s"):format(receivedValue, expectedValue)
			}
		else
			return {
				pass = false,
				message = ("Expected %s not to be divisible by %s"):format(receivedValue, expectedValue)
			}
		end
	end
})

-- spec.lua
it("should be an even number", function()
	expect(10).to.be.divisibleBy(2)
end)
```

Heavily influenced by https://jestjs.io/docs/en/expect#expectextendmatchers