### PR TITLE
Add the start of an end-to-end test suite

### DIFF
--- a/test/runner.server.lua
+++ b/test/runner.server.lua
@@ -13,11 +13,9 @@ local function findUnitTests(container, foundTests)
 	foundTests = foundTests or {}
 
 	for _, child in ipairs(container:GetChildren()) do
-		if child:IsA("ModuleScript") and not string.match(child.Name, ".*%.spec$") then
+		if child:IsA("ModuleScript") then
 			table.insert(foundTests, child)
 		end
-
-		findUnitTests(child, foundTests)
 	end
 
 	return foundTests

--- a/test/runner.server.lua
+++ b/test/runner.server.lua
@@ -13,7 +13,7 @@ local function findUnitTests(container, foundTests)
 	foundTests = foundTests or {}
 
 	for _, child in ipairs(container:GetChildren()) do
-		if child:IsA("ModuleScript") then
+		if child:IsA("ModuleScript") and not string.match(child.Name, ".*%.spec$") then
 			table.insert(foundTests, child)
 		end
 

--- a/tests/failing/error.spec.lua
+++ b/tests/failing/error.spec.lua
@@ -1,3 +1,4 @@
+-- luacheck: globals describe it
 return function()
 	describe("should fail", function()
 		it("failing", function()

--- a/tests/failing/error.spec.lua
+++ b/tests/failing/error.spec.lua
@@ -1,0 +1,7 @@
+return function()
+	describe("should fail", function()
+		it("failing", function()
+			error("Failed")
+		end)
+	end)
+end

--- a/tests/failing/fail.spec.lua
+++ b/tests/failing/fail.spec.lua
@@ -1,3 +1,4 @@
+-- luacheck: globals describe it fail
 return function()
 	describe("should fail", function()
 		it("failing", function()

--- a/tests/failing/fail.spec.lua
+++ b/tests/failing/fail.spec.lua
@@ -1,0 +1,7 @@
+return function()
+	describe("should fail", function()
+		it("failing", function()
+			fail("Failed")
+		end)
+	end)
+end

--- a/tests/failing/planning.spec.lua
+++ b/tests/failing/planning.spec.lua
@@ -1,3 +1,4 @@
+-- luacheck: globals describe it
 return function()
 	it("shouldn't run", function()
 	end)

--- a/tests/failing/planning.spec.lua
+++ b/tests/failing/planning.spec.lua
@@ -1,0 +1,6 @@
+return function()
+	it("shouldn't run", function()
+	end)
+
+	error("planning")
+end

--- a/tests/passing/empty.spec.lua
+++ b/tests/passing/empty.spec.lua
@@ -1,0 +1,7 @@
+return function()
+	describe("should pass", function()
+		it("passing", function()
+			-- An empty test should pass by default
+		end)
+	end)
+end

--- a/tests/passing/empty.spec.lua
+++ b/tests/passing/empty.spec.lua
@@ -1,3 +1,4 @@
+-- luacheck: globals describe it
 return function()
 	describe("should pass", function()
 		it("passing", function()

--- a/tests/passing/focus.spec.lua
+++ b/tests/passing/focus.spec.lua
@@ -1,0 +1,8 @@
+return function()
+	itFOCUS("run this", function()
+	end)
+
+	it("not that", function()
+		error("shouldn't happen")
+	end)
+end

--- a/tests/passing/focus.spec.lua
+++ b/tests/passing/focus.spec.lua
@@ -1,3 +1,4 @@
+-- luacheck: globals describe it itFOCUS
 return function()
 	itFOCUS("run this", function()
 	end)

--- a/tests/passing/skip.spec.lua
+++ b/tests/passing/skip.spec.lua
@@ -1,0 +1,13 @@
+return function()
+	itSKIP("skip a failing test", function()
+		error("shouldn't happen")
+	end)
+
+	describe("skip a failing block", function()
+		SKIP()
+
+		it("shouldn't run", function()
+			error("also shouldn't happen")
+		end)
+	end)
+end

--- a/tests/passing/skip.spec.lua
+++ b/tests/passing/skip.spec.lua
@@ -1,3 +1,4 @@
+-- luacheck: globals describe it itSKIP SKIP
 return function()
 	itSKIP("skip a failing test", function()
 		error("shouldn't happen")

--- a/tests/specTests.lua
+++ b/tests/specTests.lua
@@ -17,12 +17,12 @@ end
 
 local tests = {}
 for _, child in ipairs(passing:GetChildren()) do
-	tests[child.Name] = function()
+	tests["Passing tests pass: " .. child.Name] = function()
 		check(child, true)
 	end
 end
 for _, child in ipairs(failing:GetChildren()) do
-	tests[child.Name] = function()
+	tests["Failing tests fail: " .. child.Name] = function()
 		check(child, false)
 	end
 end

--- a/tests/specTests.lua
+++ b/tests/specTests.lua
@@ -1,0 +1,29 @@
+local TestEZ = require(script.Parent.Parent.TestEZ)
+
+local passing = script.Parent.passing
+local failing = script.Parent.failing
+
+local function check(test, pass)
+	TestEZ.run(test, function(results)
+		if pass then
+			assert(#results.errors == 0,
+				"Expected no errors, got " .. tostring(results.errors[1]) ..
+				" plus " .. tostring(#results.errors - 1) .. " more.")
+		else
+			assert(#results.errors > 0, "Expected some errors, got none.")
+		end
+	end)
+end
+
+local tests = {}
+for _, child in ipairs(passing:GetChildren()) do
+	tests[child.Name] = function()
+		check(child, true)
+	end
+end
+for _, child in ipairs(failing:GetChildren()) do
+	tests[child.Name] = function()
+		check(child, false)
+	end
+end
+return tests


### PR DESCRIPTION
Add a few tests of TestEZ that pass spec files through run. These are effectively end-to-end tests, but give us an easy way to verify high-level functionality, such as the api of the pending loadmodule/inject behavior.