### PR TITLE
Remove step alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # TestEZ Changelog
 
 ## Unreleased Changes
-* Remove the Try node type.
+* Remove the `try` node type.
+  * Remove the `step` alias for `it` since that's meant for use with `try`.
 * Remove the `include` global function.
 
 ## 0.2.0 (2020-03-04)

--- a/src/TestEnvironment.lua
+++ b/src/TestEnvironment.lua
@@ -133,8 +133,6 @@ function TestEnvironment.new(builder, extraEnvironment)
 		currentNode.HACK_NO_XPCALL = true
 	end
 
-	env.step = env.it
-
 	env.fit = env.itFOCUS
 	env.xit = env.itSKIP
 	env.fdescribe = env.describeFOCUS


### PR DESCRIPTION
The step alias is meant to be used with try blocks, and is currently unused in our codebase.