### PR TITLE
Document current behavior of duplicate it blocks

### DIFF
--- a/tests/passing/duplicateIt.spec.lua
+++ b/tests/passing/duplicateIt.spec.lua
@@ -1,3 +1,5 @@
+-- luacheck: globals describe it
+
 return function()
 	describe("multiple it blocks with the same description", function()
 		it("only the last runs", function()

--- a/tests/passing/duplicateIt.spec.lua
+++ b/tests/passing/duplicateIt.spec.lua
@@ -1,0 +1,16 @@
+return function()
+	describe("multiple it blocks with the same description", function()
+		it("only the last runs", function()
+			error("first")
+		end)
+		it("only the last runs", function()
+			error("second")
+		end)
+		it("only the last runs", function()
+			error("third")
+		end)
+		it("only the last runs", function()
+			-- This is the only one that will run
+		end)
+	end)
+end


### PR DESCRIPTION
Add a test that demonstrates the current behavior of tests when multiple it blocks use the same description.