### PR TITLE
Demonstrate current behavior of duplicate describes

### DIFF
--- a/tests/passing/duplicateDescribe.lua
+++ b/tests/passing/duplicateDescribe.lua
@@ -1,0 +1,14 @@
+-- luacheck: globals describe it
+
+return function()
+	describe("with the same description", function()
+		it("should not run this", function()
+			error("this won't happen")
+		end)
+	end)
+
+	describe("with the same description", function()
+		it("should only run this test", function()
+		end)
+	end)
+end


### PR DESCRIPTION
This is not the behavior I expected, but currently a duplicate describe block will overwrite an older one.