### PR TITLE
Fix duplicate describe block test

### DIFF
--- a/tests/failing/duplicateDescribe.spec.lua
+++ b/tests/failing/duplicateDescribe.spec.lua
@@ -2,13 +2,13 @@
 
 return function()
 	describe("with the same description", function()
-		it("should not run this", function()
-			error("this won't happen")
+		it("should run this", function()
+			error("this won't get overwritten")
 		end)
 	end)
 
 	describe("with the same description", function()
-		it("should only run this test", function()
+		it("should also run this", function()
 		end)
 	end)
 end

--- a/tests/planner.lua
+++ b/tests/planner.lua
@@ -62,6 +62,11 @@ return {
 			"planning b test1",
 			"planning b test2",
 			"planning b test2 test3",
+			"planning d",
+			"planning d test4",
+			"planning d test4 test5",
+			"planning d test4 test6",
+			"planning d test4 test7",
 		}))
 	end,
 	["it should mark skipped tests as skipped"] = function()
@@ -74,6 +79,11 @@ return {
 			"planning b",
 			"planning b test1",
 			"planning b test2 test3", -- This isn't marked skip, its parent is
+			"planning d",
+			"planning d test4",
+			"planning d test4 test5",
+			"planning d test4 test6",
+			"planning d test4 test7",
 		}, true))
 	end,
 	["it should skip tests that don't match the filter"] = function()

--- a/tests/planning/d.spec.lua
+++ b/tests/planning/d.spec.lua
@@ -1,0 +1,21 @@
+-- luacheck: globals describe it SKIP
+
+return function()
+	describe("test4", function()
+		it("test5", function()
+		end)
+
+		it("test6", function()
+		end)
+	end)
+
+	describe("test4", function()
+		-- Duplicate describe blocks should get merged.
+		it("test5", function()
+			-- Duplicate it blocks will get overwritten.
+		end)
+
+		it("test7", function()
+		end)
+	end)
+end


### PR DESCRIPTION
I forgot the .spec in the test name, so it was erroneously marked as passing. Fixed that and added a more explicit test of duplicate blocks to the planner test.