### PR TITLE
Makes a few improvements for CI usability of testez-cli

### DIFF
--- a/testez-cli/src/tools/roblox_cli.rs
+++ b/testez-cli/src/tools/roblox_cli.rs
@@ -7,9 +7,6 @@ use roblox_install::RobloxStudio;
 pub fn roblox_cli_run(place_path: &Path, entrypoint_path: &str, as_core_script: bool) {
     let place_arg = place_path.to_str().unwrap();
 
-    let install = RobloxStudio::locate().expect("couldn't find Roblox Studio; is it installed?");
-    let content_path_arg = install.content_path().to_str().unwrap();
-
     log::trace!("Executing 'roblox-cli run'");
 
     let mut command = Command::new("roblox-cli");
@@ -19,9 +16,14 @@ pub fn roblox_cli_run(place_path: &Path, entrypoint_path: &str, as_core_script: 
         &place_arg,
         "--entrypoint",
         entrypoint_path,
-        "--assetFolder",
-        &content_path_arg,
     ]);
+
+    let install = RobloxStudio::locate();
+    if let Ok(install_location) = install {
+        let content_path_arg = install_location.content_path().to_str().unwrap();
+        command.arg("--assetFolder");
+        command.arg(&content_path_arg);
+    }
 
     if as_core_script {
         command.arg("--load.asRobloxScript");

--- a/testez-cli/src/tools/roblox_cli.rs
+++ b/testez-cli/src/tools/roblox_cli.rs
@@ -1,6 +1,5 @@
 //! Interface to Roblox-CLI.
 
-use log;
 use std::{path::Path, process::Command};
 
 use roblox_install::RobloxStudio;

--- a/testez-cli/src/tools/roblox_cli.rs
+++ b/testez-cli/src/tools/roblox_cli.rs
@@ -1,10 +1,7 @@
 //! Interface to Roblox-CLI.
 
 use log;
-use std::{
-    path::Path,
-    process::{self, Command},
-};
+use std::{path::Path, process::Command};
 
 use roblox_install::RobloxStudio;
 
@@ -37,10 +34,5 @@ pub fn roblox_cli_run(place_path: &Path, entrypoint_path: &str, as_core_script: 
         .status()
         .expect("failed to execute Roblox-CLI; is it installed?");
 
-    if !status.success() {
-        log::error!("Roblox-CLI exited with an error");
-        process::exit(1);
-    } else {
-        process::exit(0);
-    }
+    assert!(status.success(), "Roblox-CLI exited with an error.");
 }

--- a/testez-cli/src/tools/roblox_cli.rs
+++ b/testez-cli/src/tools/roblox_cli.rs
@@ -18,8 +18,7 @@ pub fn roblox_cli_run(place_path: &Path, entrypoint_path: &str, as_core_script: 
         entrypoint_path,
     ]);
 
-    let install = RobloxStudio::locate();
-    if let Ok(install_location) = install {
+    if let Ok(install_location) = RobloxStudio::locate() {
         let content_path_arg = install_location.content_path().to_str().unwrap();
         command.arg("--assetFolder");
         command.arg(&content_path_arg);

--- a/testez-cli/src/tools/roblox_cli.rs
+++ b/testez-cli/src/tools/roblox_cli.rs
@@ -1,6 +1,10 @@
 //! Interface to Roblox-CLI.
 
-use std::{path::Path, process::Command};
+use log;
+use std::{
+    path::Path,
+    process::{self, Command},
+};
 
 use roblox_install::RobloxStudio;
 
@@ -33,5 +37,10 @@ pub fn roblox_cli_run(place_path: &Path, entrypoint_path: &str, as_core_script: 
         .status()
         .expect("failed to execute Roblox-CLI; is it installed?");
 
-    assert!(status.success(), "Roblox-CLI exited with an error.");
+    if !status.success() {
+        log::error!("Roblox-CLI exited with an error");
+        process::exit(1);
+    } else {
+        process::exit(0);
+    }
 }


### PR DESCRIPTION
This change does the following:
* Removes the requirement that roblox studio be installed somewhere (many projects won't need access to assets anyway)
   * If I recall correctly, roblox-cli shouldn't actually need it specified anymore either
* ~~Makes sure to exit with an error code if roblox-cli does so; otherwise, CI jobs will come up green even when tests fail~~

EDIT: The error code issue was related to powershell on GitHub Actions, so I was mistaken in trying to fix it here.