### PR TITLE
Implement sorting using full test path instead of sorting just modules within last folder

### DIFF
--- a/.github/workflows/clabot.yml
+++ b/.github/workflows/clabot.yml
@@ -14,7 +14,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        whitelist: "LPGhatguy,ZoteTheMighty,cliffchapmanrbx,MagiMaster,MisterUncloaked"
+        whitelist: "LPGhatguy,ZoteTheMighty,cliffchapmanrbx,MagiMaster,MisterUncloaked,amatosov-rbx"
         use-remote-repo: true
         remote-repo-name: "roblox/cla-bot-store"
         remote-repo-pat: ${{ secrets.CLA_REMOTE_REPO_PAT }}

--- a/src/TestBootstrap.lua
+++ b/src/TestBootstrap.lua
@@ -66,6 +66,9 @@ function TestBootstrap:getModulesImpl(root, modules, current)
 	end
 end
 
+--[[
+	Find all the ModuleScripts in this tree that are tests.
+]]
 function TestBootstrap:getModules(root)
 	local modules = {}
 

--- a/src/TestBootstrap.lua
+++ b/src/TestBootstrap.lua
@@ -61,7 +61,7 @@ function TestBootstrap:getModulesImpl(root, modules, current)
 		table.insert(modules, {
 			method = method,
 			path = path,
-			pathStringLowercase = pathString:lower()
+			pathStringForSorting = pathString:lower()
 		})
 	end
 end
@@ -118,10 +118,6 @@ function TestBootstrap:run(roots, reporter, otherOptions)
 			table.insert(modules, newModule)
 		end
 	end
-
-	table.sort(modules, function(a, b)
-		return a.pathStringLowercase < b.pathStringLowercase
-	end)
 
 	local afterModules = tick()
 

--- a/src/TestPlanner.lua
+++ b/src/TestPlanner.lua
@@ -12,11 +12,24 @@ local TestPlanner = {}
 
 	These functions should call a combination of `describe` and `it` (and their
 	variants), which will be turned into a test plan to be executed.
+
+	Parameters:
+		- modulesList - list of tables describing test modules {
+			method, -- specification function described above
+			path, -- array of parent entires, first element is the leaf that owns `method`
+			pathStringForSorting -- a string representation of `path`, used for sorting of the test plan
+		}
+		- testNamePattern - Only tests matching this Lua pattern string will run. Pass empty or nil to run all tests
+		- extraEnvironment - Lua table holding additional functions and variables to be injected into the specification function during execution
 ]]
-function TestPlanner.createPlan(specFunctions, testNamePattern, extraEnvironment)
+function TestPlanner.createPlan(modulesList, testNamePattern, extraEnvironment)
 	local plan = TestPlan.new(testNamePattern, extraEnvironment)
 
-	for _, module in ipairs(specFunctions) do
+	table.sort(modulesList, function(a, b)
+		return a.pathStringForSorting < b.pathStringForSorting
+	end)
+
+	for _, module in ipairs(modulesList) do
 		plan:addRoot(module.path, module.method)
 	end
 

--- a/src/TestPlanner.lua
+++ b/src/TestPlanner.lua
@@ -20,7 +20,8 @@ local TestPlanner = {}
 			pathStringForSorting -- a string representation of `path`, used for sorting of the test plan
 		}
 		- testNamePattern - Only tests matching this Lua pattern string will run. Pass empty or nil to run all tests
-		- extraEnvironment - Lua table holding additional functions and variables to be injected into the specification function during execution
+		- extraEnvironment - Lua table holding additional functions and variables to be injected into the specification
+							function during execution
 ]]
 function TestPlanner.createPlan(modulesList, testNamePattern, extraEnvironment)
 	local plan = TestPlan.new(testNamePattern, extraEnvironment)


### PR DESCRIPTION
When module scripts are loaded from file system (e.g. using lua or rojo tools) their order depends on the file system and system API internals. That means different platforms Windows, macOS and Linux will have folders and files loaded differently. Even more, within the same platform binaries compiled for x64 and x86 can have different sorting order. On top of that, order is going to change when files are added or deleted. That results in ultimately random execution order between folders and can cause flakiness if tests have any sort of dependency (e.g. one test mutates global state, other test uses it)
