### PR TITLE
Change installing CLI command in README

### DIFF
--- a/testez-cli/README.md
+++ b/testez-cli/README.md
@@ -18,7 +18,7 @@ It can also be compiled from source in this repository. Building from source req
 cargo build
 
 # To build and install
-cargo install
+cargo install --path .
 ```
 
 ## Usage


### PR DESCRIPTION
Since cargo no longer supports building/installing binaries for packages in the current directory with `cargo install` (as seen in the image below), I've changed the command to make sure that users will still be able to build & install the CLI.

![image](https://user-images.githubusercontent.com/48777426/84578716-c58b1d80-ad7c-11ea-8c7d-e6231b6f7013.png)
