### PR TITLE
Take over the require cache within a test run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   * Remove the `step` alias for `it` since that's meant for use with `try`.
 * Remove the `include` global function.
 * Remove `HACK_NO_XPCALL`. With recent changes to the definition of xpcall, this is no longer necessary. Since people are still using it, it will now print out a warning asking them to delete that call instead.
+* Guarantee that `init.spec.lua` will run before any `it` or `describe` blocks in the folder under it.
 * Major changes to the internals of test planning.
   * The major visible change is that `describe` and `it` blocks with duplicate descriptions will now not overwrite the earlier copies of those nodes.
   * Duplicate `it` nodes within one `describe` will raise an error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # TestEZ Changelog
 
 ## Unreleased Changes
+* Remove the lifecycle hooks from the session tree. This prevents the `[?]` spam from the reporter not recognizing these nodes.
 
 ## 0.3.1 (2020-06-22)
 * Further simplify `beforeAll` handling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Change the way errors are collected to call tostring on them before further processing.
   * Luau allows non-string errors, but not concatenating non-strings or passing non-strings to `debug.traceback` as a message, so TestRunner needs to do that step. This is a temporary fix as the better solution would be to retain the error in object form for as long as possible to give the reporter more to work with.
   * This also makes a slight change to what's in the traceback to eliminate the unnecessary line mentioning the error collection function.
+* Add a deprecation notice for uses of extraEnvironment.
 
 ## 0.3.1 (2020-06-22)
 * Further simplify `beforeAll` handling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Luau allows non-string errors, but not concatenating non-strings or passing non-strings to `debug.traceback` as a message, so TestRunner needs to do that step. This is a temporary fix as the better solution would be to retain the error in object form for as long as possible to give the reporter more to work with.
   * This also makes a slight change to what's in the traceback to eliminate the unnecessary line mentioning the error collection function.
 * Add a deprecation notice for uses of extraEnvironment.
+* Guarantee that `init.spec.lua` will run before any `it` or `describe` blocks in the folder under it.
 
 ## 0.3.1 (2020-06-22)
 * Further simplify `beforeAll` handling.
@@ -21,7 +22,6 @@
   * Remove the `step` alias for `it` since that's meant for use with `try`.
 * Remove the `include` global function.
 * Remove `HACK_NO_XPCALL`. With recent changes to the definition of xpcall, this is no longer necessary. Since people are still using it, it will now print out a warning asking them to delete that call instead.
-* Guarantee that `init.spec.lua` will run before any `it` or `describe` blocks in the folder under it.
 * Major changes to the internals of test planning.
   * The major visible change is that `describe` and `it` blocks with duplicate descriptions will now not overwrite the earlier copies of those nodes.
   * Duplicate `it` nodes within one `describe` will raise an error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased Changes
 * Remove the lifecycle hooks from the session tree. This prevents the `[?]` spam from the reporter not recognizing these nodes.
+* Change the way errors are collected to call tostring on them before further processing.
+  * Luau allows non-string errors, but not concatenating non-strings or passing non-strings to `debug.traceback` as a message, so TestRunner needs to do that step. This is a temporary fix as the better solution would be to retain the error in object form for as long as possible to give the reporter more to work with.
+  * This also makes a slight change to what's in the traceback to eliminate the unnecessary line mentioning the error collection function.
 
 ## 0.3.1 (2020-06-22)
 * Further simplify `beforeAll` handling.

--- a/src/TestBootstrap.lua
+++ b/src/TestBootstrap.lua
@@ -54,7 +54,7 @@ function TestBootstrap:getModulesImpl(root, modules, current)
 	current = current or root
 
 	if isSpecScript(current) then
-		local method = require(current)
+		local method = debug.loadmodule(current)
 		local path = getPath(current, root)
 		local pathString = toStringPath(path)
 

--- a/src/TestPlan.lua
+++ b/src/TestPlan.lua
@@ -9,21 +9,19 @@ local TestEnum = require(script.Parent.TestEnum)
 local Expectation = require(script.Parent.Expectation)
 
 local REQUIRE_CACHE_KEY = {}
+local requireCache = {}
 
 local function newEnvironment(parentEnvironment, currentNode, extraEnvironment)
 	local env = {}
 
-	local requireMeta = {}
-	if parentEnvironment then
-		requireMeta = {__index = parentEnvironment[REQUIRE_CACHE_KEY]}
-	end
-
-	local requireCache = setmetatable({}, requireMeta)
+	-- All nodes in a tree currently share a cache
+	local requireCache = parentEnvironment and parentEnvironment[REQUIRE_CACHE_KEY] or {}
 	env[REQUIRE_CACHE_KEY] = requireCache
 
 	if extraEnvironment then
 		if type(extraEnvironment) ~= "table" then
 			error(("Bad argument #3 to newEnvironment. Expected table, got %s"):format(
+
 				typeof(extraEnvironment)), 2)
 		end
 

--- a/src/TestPlan.lua
+++ b/src/TestPlan.lua
@@ -204,6 +204,14 @@ TestPlan.__index = TestPlan
 	Create a new, empty TestPlan.
 ]]
 function TestPlan.new(testNamePattern, extraEnvironment)
+	if extraEnvironment and next(extraEnvironment) then
+		warn(
+			"extraEnvironment is deprecated and will be removed in the near future. " ..
+			"Please use an init.spec.lua file and the test context to pass in anything " ..
+			"that is currently in extraEnvironment."
+		)
+	end
+
 	local plan = {
 		children = {},
 		testNamePattern = testNamePattern,

--- a/src/TestPlan.lua
+++ b/src/TestPlan.lua
@@ -188,7 +188,9 @@ function TestNode:expand()
 	end
 	setfenv(self.callback, callbackEnv)
 
-	local success, result = xpcall(self.callback, debug.traceback)
+	local success, result = xpcall(self.callback, function(message)
+		return debug.traceback(tostring(message), 2)
+	end)
 
 	if not success then
 		self.loadError = result

--- a/src/TestPlanner.lua
+++ b/src/TestPlanner.lua
@@ -34,6 +34,7 @@ function TestPlanner.createPlan(modulesList, testNamePattern, extraEnvironment)
 		plan:addRoot(module.path, module.method)
 	end
 
+	plan:finalize()
 	return plan
 end
 

--- a/src/TestRunner.lua
+++ b/src/TestRunner.lua
@@ -134,9 +134,8 @@ function TestRunner.runPlanNode(session, planNode, lifecycleHooks)
 
 	if not halt then
 		for _, childPlanNode in ipairs(planNode.children) do
-			session:pushNode(childPlanNode)
-
 			if childPlanNode.type == TestEnum.NodeType.It then
+				session:pushNode(childPlanNode)
 				if session:shouldSkip() then
 					session:setSkipped()
 				else
@@ -148,7 +147,9 @@ function TestRunner.runPlanNode(session, planNode, lifecycleHooks)
 						session:setError(errorMessage)
 					end
 				end
+				session:popNode()
 			elseif childPlanNode.type == TestEnum.NodeType.Describe then
+				session:pushNode(childPlanNode)
 				TestRunner.runPlanNode(session, childPlanNode, lifecycleHooks)
 
 				-- Did we have an error trying build a test plan?
@@ -158,9 +159,8 @@ function TestRunner.runPlanNode(session, planNode, lifecycleHooks)
 				else
 					session:setStatusFromChildren()
 				end
+				session:popNode()
 			end
-
-			session:popNode()
 		end
 	end
 

--- a/src/TestRunner.lua
+++ b/src/TestRunner.lua
@@ -67,7 +67,7 @@ function TestRunner.runPlanNode(session, planNode, lifecycleHooks)
 			end
 
 			success = false
-			errorMessage = messagePrefix .. message .. "\n" .. debug.traceback()
+			errorMessage = messagePrefix .. debug.traceback(tostring(message), 2)
 		end
 
 		local context = session:getContext()
@@ -77,7 +77,7 @@ function TestRunner.runPlanNode(session, planNode, lifecycleHooks)
 				callback(context)
 			end,
 			function(message)
-				return messagePrefix .. message .. "\n" .. debug.traceback()
+				return messagePrefix .. debug.traceback(tostring(message), 2)
 			end
 		)
 

--- a/tests/expandOrder.lua
+++ b/tests/expandOrder.lua
@@ -1,0 +1,89 @@
+local TestEZ = require(script.Parent.Parent.TestEZ)
+
+return {
+	["init.spec.lua is run before children are expanded"] = function()
+		local initialized = false
+
+		local plan = TestEZ.TestPlanner.createPlan({
+			{
+				method = function()
+					assert(initialized, "init.spec was not called before bar.spec")
+				end,
+				path = {'bar.spec', 'foo'}
+			},
+			{
+				method = function()
+					initialized = true
+				end,
+				path = {'foo'}
+			},
+		})
+
+		local results = TestEZ.TestRunner.runPlan(plan)
+		assert(#results.errors == 0, "init test failed: " .. tostring(results.errors[1]))
+	end,
+	["init.spec.lua afterAll can correctly undo changes"] = function()
+		local initialized = false
+
+		-- luacheck: globals it
+		local plan = TestEZ.TestPlanner.createPlan({
+			{
+				method = function()
+					print("Ad")
+					it("A", function()
+						print("Ai")
+						assert(not initialized, "initialized was true in foo/a.spec")
+					end)
+				end,
+				path = {'a.spec', 'foo'}
+			},
+			{
+				method = function()
+					print("Bd")
+					it("B", function()
+						print("Bi")
+						assert(initialized, "initialized was false in foo/bar/b.spec")
+					end)
+				end,
+				path = {'b.spec', 'bar', 'foo'}
+			},
+			{
+				method = function()
+					print("Init")
+					initialized = true
+
+					-- luacheck: globals afterAll
+					afterAll(function()
+						print("After")
+						initialized = false
+					end)
+				end,
+				path = {'bar', 'foo'}
+			},
+			{
+				method = function()
+					print("Cd")
+					it("C", function()
+						print("Ci")
+						assert(initialized, "initialized was false in foo/bar/c.spec")
+					end)
+				end,
+				path = {'c.spec', 'bar', 'foo'}
+			},
+			{
+				method = function()
+					print("Dd")
+					it("D", function()
+						print("Di")
+						assert(not initialized, "initialized was true in foo/d.spec")
+					end)
+				end,
+				path = {'d.spec', 'foo'}
+			},
+		})
+
+		local results = TestEZ.TestRunner.runPlan(plan)
+		assert(#results.errors == 0, "init test failed:\n" ..
+			table.concat(results.errors, "\n"))
+	end,
+}

--- a/tests/expandOrder.lua
+++ b/tests/expandOrder.lua
@@ -1,3 +1,5 @@
+-- luacheck: globals it beforeAll afterAll
+
 local TestEZ = require(script.Parent.Parent.TestEZ)
 
 return {
@@ -9,13 +11,15 @@ return {
 				method = function()
 					assert(initialized, "init.spec was not called before bar.spec")
 				end,
-				path = {'bar.spec', 'foo'}
+				path = {'bar.spec', 'foo'},
+				pathStringForSorting = "foo bar.spec",
 			},
 			{
 				method = function()
 					initialized = true
 				end,
-				path = {'foo'}
+				path = {'foo'},
+				pathStringForSorting = "foo",
 			},
 		})
 
@@ -25,60 +29,55 @@ return {
 	["init.spec.lua afterAll can correctly undo changes"] = function()
 		local initialized = false
 
-		-- luacheck: globals it
 		local plan = TestEZ.TestPlanner.createPlan({
 			{
 				method = function()
-					print("Ad")
 					it("A", function()
-						print("Ai")
 						assert(not initialized, "initialized was true in foo/a.spec")
 					end)
 				end,
-				path = {'a.spec', 'foo'}
+				path = {'a.spec', 'foo'},
+				pathStringForSorting = "foo a.spec",
 			},
 			{
 				method = function()
-					print("Bd")
 					it("B", function()
-						print("Bi")
 						assert(initialized, "initialized was false in foo/bar/b.spec")
 					end)
 				end,
-				path = {'b.spec', 'bar', 'foo'}
+				path = {'b.spec', 'bar', 'foo'},
+				pathStringForSorting = "foo bar b.spec",
 			},
 			{
 				method = function()
-					print("Init")
-					initialized = true
+					beforeAll(function()
+						initialized = true
+					end)
 
-					-- luacheck: globals afterAll
 					afterAll(function()
-						print("After")
 						initialized = false
 					end)
 				end,
-				path = {'bar', 'foo'}
+				path = {'bar', 'foo'},
+				pathStringForSorting = "foo bar",
 			},
 			{
 				method = function()
-					print("Cd")
 					it("C", function()
-						print("Ci")
 						assert(initialized, "initialized was false in foo/bar/c.spec")
 					end)
 				end,
-				path = {'c.spec', 'bar', 'foo'}
+				path = {'c.spec', 'bar', 'foo'},
+				pathStringForSorting = "foor bar c.spec",
 			},
 			{
 				method = function()
-					print("Dd")
 					it("D", function()
-						print("Di")
 						assert(not initialized, "initialized was true in foo/d.spec")
 					end)
 				end,
-				path = {'d.spec', 'foo'}
+				path = {'d.spec', 'foo'},
+				pathStringForSorting = "foo d.spec",
 			},
 		})
 

--- a/tests/modules/a.lua
+++ b/tests/modules/a.lua
@@ -1,0 +1,3 @@
+local b = require(script.Parent.b)
+
+return b(1) -- 2

--- a/tests/modules/b.lua
+++ b/tests/modules/b.lua
@@ -1,0 +1,3 @@
+return function(x)
+	return x + 1
+end

--- a/tests/passing/requires.spec.lua
+++ b/tests/passing/requires.spec.lua
@@ -1,0 +1,17 @@
+-- luacheck: globals it expect
+
+return function()
+	local a = require(script.Parent.Parent.modules.a)
+	local b = require(script.Parent.Parent.modules.b)
+
+	it("requires should work properly", function()
+		expect(a).to.equal(2)
+		expect(b(2)).to.equal(3)
+	end)
+
+	it("require cache works under normal circumstances", function()
+		local b2 = require(script.Parent.Parent.modules.b)
+
+		expect(b).to.equal(b2)
+	end)
+end

--- a/tests/planning/init.spec.lua
+++ b/tests/planning/init.spec.lua
@@ -1,0 +1,4 @@
+-- This should be added to the "planning" node of the tree instead of creating
+-- a new node.
+return function()
+end


### PR DESCRIPTION
Use loadmodule to have TestEZ manage the require cache for the tests it's running. This is doesn't do much on its own, but is needed for the monkey patching changes to be added later. Requires coming from the launcher script will no longer touch anything inside tests after this, so extraEnvironment will not work and global configuration will need to be done within init.spec.lua files.