### PR TITLE
Update cli runner script to use the latest roblox-cli API

### DIFF
--- a/testez-cli/src/test-runner.lua
+++ b/testez-cli/src/test-runner.lua
@@ -28,7 +28,7 @@ if __LEMUR__ then
 	end
 elseif isRobloxCli then
 	platform.exit = function(statusCode)
-		ProcessService:Exit(statusCode)
+		ProcessService:ExitAsync(statusCode)
 	end
 
 	platform.error = function(message)


### PR DESCRIPTION
Updates the runner script used by testez-cli to use the latest API that roblox-cli exports. This shouldn't change from here on.

I'm not sure how to make this compatible with older versions of roblox-cli, but I think our usage is limited enough that it shouldn't matter.