### PR TITLE
Add error message assertion to expectation.throw

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -120,4 +120,12 @@ end).to.throw()
 expect(function()
 	-- I don't throw!
 end).never.to.throw()
+
+expect(function()
+	error("nope")
+end).to.throw("nope")
+
+expect(function()
+	error("foo")
+end).never.to.throw("bar")
 ```

--- a/src/Expectation.lua
+++ b/src/Expectation.lua
@@ -243,15 +243,26 @@ function Expectation:throw(messageSubstring)
 		result = errorMatch
 	end
 
-	local message = formatMessage(self.successCondition,
-		("Expected function to throw an error%s, but it %s"):format(
-			messageSubstring and (" containing %q"):format(messageSubstring) or "",
-			err and ("threw %q"):format(err) or "did not throw."
-		),
-		("Expected function to succeed, but it threw an error: %s"):format(
-			tostring(err)
+	local message
+
+	if messageSubstring then
+		message = formatMessage(self.successCondition,
+			("Expected function to throw an error containing %q, but it %s"):format(
+				messageSubstring,
+				err and ("threw %q"):format(err) or "did not throw."
+			),
+			("Expected function to succeed, but it threw an error: %s"):format(
+				tostring(err)
+			)
 		)
-	)
+	else
+		message = formatMessage(self.successCondition,
+			"Expected function to throw an error, but it did not throw.",
+			("Expected function to succeed, but it threw an error: %s"):format(
+				tostring(err)
+			)
+		)
+	end
 
 	assertLevel(result, message, 3)
 	self:_resetModifiers()

--- a/src/Expectation.lua
+++ b/src/Expectation.lua
@@ -230,14 +230,24 @@ function Expectation:near(otherValue, limit)
 end
 
 --[[
-	Assert that our functoid expectation value throws an error when called
+	Assert that our functoid expectation value throws an error when called.
+	An optional error message can be passed to assert that the error message
+	contains the given value.
 ]]
-function Expectation:throw()
+function Expectation:throw(messageSubstring)
 	local ok, err = pcall(self.value)
 	local result = ok ~= self.successCondition
 
+	if messageSubstring and not ok then
+		local errorMatch = err:find(messageSubstring, 1, true)
+		result = errorMatch
+	end
+
 	local message = formatMessage(self.successCondition,
-		"Expected function to throw an error, but it did not.",
+		("Expected function to throw an error%s, but it %s"):format(
+			messageSubstring and (" containing %q"):format(messageSubstring) or "",
+			err and ("threw %q"):format(err) or "did not throw."
+		),
 		("Expected function to succeed, but it threw an error: %s"):format(
 			tostring(err)
 		)

--- a/src/Expectation.lua
+++ b/src/Expectation.lua
@@ -239,8 +239,7 @@ function Expectation:throw(messageSubstring)
 	local result = ok ~= self.successCondition
 
 	if messageSubstring and not ok then
-		local errorMatch = err:find(messageSubstring, 1, true)
-		result = errorMatch
+		result = err:find(messageSubstring, 1, true) ~= nil
 	end
 
 	local message

--- a/src/Expectation.lua
+++ b/src/Expectation.lua
@@ -239,7 +239,11 @@ function Expectation:throw(messageSubstring)
 	local result = ok ~= self.successCondition
 
 	if messageSubstring and not ok then
-		result = err:find(messageSubstring, 1, true) ~= nil
+		if self.successCondition then
+			result = err:find(messageSubstring, 1, true) ~= nil
+		else
+			result = err:find(messageSubstring, 1, true) == nil
+		end
 	end
 
 	local message
@@ -248,9 +252,10 @@ function Expectation:throw(messageSubstring)
 		message = formatMessage(self.successCondition,
 			("Expected function to throw an error containing %q, but it %s"):format(
 				messageSubstring,
-				err and ("threw %q"):format(err) or "did not throw."
+				err and ("threw: %s"):format(err) or "did not throw."
 			),
-			("Expected function to succeed, but it threw an error: %s"):format(
+			("Expected function to never throw an error containing %q, but it threw: %s"):format(
+				messageSubstring,
 				tostring(err)
 			)
 		)

--- a/tests/Expectation.lua
+++ b/tests/Expectation.lua
@@ -89,7 +89,7 @@ return {
 
         assert(not success, "should fail")
         assert(
-            message:match("Expected function to throw an error containing \"foo\", but it threw \".+%.lua:%d+: oof\""),
+            message:match("Expected function to throw an error containing \"foo\", but it threw: .+%.lua:%d+: oof"),
             ("Error message does not match:\n%s\n"):format(message)
         )
     end,
@@ -105,6 +105,24 @@ return {
         end)
 
         assert(success, "should succeed")
+    end,
+    ["it should fail if a throwing function is expected to never throw a substring of the message"] = function()
+        local function shouldThrow()
+            error("foo-oof")
+        end
+
+        local expect = Expectation.new(shouldThrow)
+
+        local success, message = pcall(function()
+            expect.never:throw("oof")
+        end)
+
+        assert(not success, "should fail")
+        assert(
+            message:match("Expected function to never throw an error containing \"oof\", "
+                .. "but it threw: .+%.lua:%d+: foo%-oof"),
+            ("Error message does not match:\n%s\n"):format(message)
+        )
     end,
     ["it should succeed if types match"] = function()
         local expectNumber = Expectation.new(5)

--- a/tests/Expectation.lua
+++ b/tests/Expectation.lua
@@ -93,6 +93,18 @@ return {
             ("Error message does not match:\n%s\n"):format(message)
         )
     end,
+    ["should succeed if it doesn't fail when it was expecting to never throw with a message"] = function()
+        local function shouldNotThrow()
+        end
+
+        local expect = Expectation.new(shouldNotThrow)
+
+        local success = pcall(function()
+            expect.never:throw("foo")
+        end)
+
+        assert(success, "should succeed")
+    end,
     ["it should succeed if a throwing function is expected to throw a substring of the message"] = function()
         local function shouldThrow()
             error("foo-oof")

--- a/tests/Expectation.lua
+++ b/tests/Expectation.lua
@@ -60,6 +60,52 @@ return {
             ("Error message does not match:\n%s\n"):format(message)
         )
     end,
+    ["it should fail if an empty function is expected to throw with a message"] = function()
+        local function shouldNotThrow()
+        end
+
+        local expect = Expectation.new(shouldNotThrow)
+
+        local success, message = pcall(function()
+            expect:throw("foo")
+        end)
+
+        assert(not success, "should fail")
+        assert(
+            message:match("Expected function to throw an error containing \"foo\", but it did not."),
+            ("Error message does not match:\n%s\n"):format(message)
+        )
+    end,
+    ["it should fail if a throwing function is expected to throw with a different error message"] = function()
+        local function shouldThrow()
+            error("oof")
+        end
+
+        local expect = Expectation.new(shouldThrow)
+
+        local success, message = pcall(function()
+            expect:throw("foo")
+        end)
+
+        assert(not success, "should fail")
+        assert(
+            message:match("Expected function to throw an error containing \"foo\", but it threw \".+%.lua:%d+: oof\""),
+            ("Error message does not match:\n%s\n"):format(message)
+        )
+    end,
+    ["it should succeed if a throwing function is expected to throw a substring of the message"] = function()
+        local function shouldThrow()
+            error("foo-oof")
+        end
+
+        local expect = Expectation.new(shouldThrow)
+
+        local success = pcall(function()
+            expect:throw("oof")
+        end)
+
+        assert(success, "should succeed")
+    end,
     ["it should succeed if types match"] = function()
         local expectNumber = Expectation.new(5)
         local expectString = Expectation.new("Foo")


### PR DESCRIPTION
This will add the following feature:

```lua
local function throw()
    error("an error happened")
end

expect(throw).to.throw("error happened")
```

The message passed to `throw` is searched in the error thrown in plain. The reason is that it encourage the person writing the test to make sure that the error thrown is deterministic.  