### PR TITLE
Update reporters to not print lifecycle nodes

### DIFF
--- a/src/Reporters/TextReporter.lua
+++ b/src/Reporters/TextReporter.lua
@@ -25,32 +25,34 @@ local function reportNode(node, buffer, level)
 	buffer = buffer or {}
 	level = level or 0
 
-	if node.status == TestEnum.TestStatus.Skipped then
-		return buffer
-	end
+	if node.planNode.type == TestEnum.NodeType.It or node.planNode.type == TestEnum.NodeType.Describe then
+		if node.status == TestEnum.TestStatus.Skipped then
+			return buffer
+		end
 
-	local line
+		local line
 
-	if node.status then
-		local symbol = STATUS_SYMBOLS[node.status] or UNKNOWN_STATUS_SYMBOL
+		if node.status then
+			local symbol = STATUS_SYMBOLS[node.status] or UNKNOWN_STATUS_SYMBOL
 
-		line = ("%s[%s] %s"):format(
-			INDENT:rep(level),
-			symbol,
-			node.planNode.phrase
-		)
-	else
-		line = ("%s%s"):format(
-			INDENT:rep(level),
-			node.planNode.phrase
-		)
-	end
+			line = ("%s[%s] %s"):format(
+				INDENT:rep(level),
+				symbol,
+				node.planNode.phrase
+			)
+		else
+			line = ("%s%s"):format(
+				INDENT:rep(level),
+				node.planNode.phrase
+			)
+		end
 
-	table.insert(buffer, line)
-	table.sort(node.children, compareNodes)
+		table.insert(buffer, line)
+		table.sort(node.children, compareNodes)
 
-	for _, child in ipairs(node.children) do
-		reportNode(child, buffer, level + 1)
+		for _, child in ipairs(node.children) do
+			reportNode(child, buffer, level + 1)
+		end
 	end
 
 	return buffer

--- a/src/Reporters/TextReporterQuiet.lua
+++ b/src/Reporters/TextReporterQuiet.lua
@@ -23,26 +23,28 @@ local function reportNode(node, buffer, level)
 	buffer = buffer or {}
 	level = level or 0
 
-	if node.status == TestEnum.TestStatus.Skipped then
-		return buffer
-	end
+	if node.planNode.type == TestEnum.NodeType.It or node.planNode.type == TestEnum.NodeType.Describe then
+		if node.status == TestEnum.TestStatus.Skipped then
+			return buffer
+		end
 
-	local line
+		local line
 
-	if node.status ~= TestEnum.TestStatus.Success then
-		local symbol = STATUS_SYMBOLS[node.status] or UNKNOWN_STATUS_SYMBOL
+		if node.status ~= TestEnum.TestStatus.Success then
+			local symbol = STATUS_SYMBOLS[node.status] or UNKNOWN_STATUS_SYMBOL
 
-		line = ("%s[%s] %s"):format(
-			INDENT:rep(level),
-			symbol,
-			node.planNode.phrase
-		)
-	end
+			line = ("%s[%s] %s"):format(
+				INDENT:rep(level),
+				symbol,
+				node.planNode.phrase
+			)
+		end
 
-	table.insert(buffer, line)
+		table.insert(buffer, line)
 
-	for _, child in ipairs(node.children) do
-		reportNode(child, buffer, level + 1)
+		for _, child in ipairs(node.children) do
+			reportNode(child, buffer, level + 1)
+		end
 	end
 
 	return buffer


### PR DESCRIPTION
This prevents lifecycle events like beforeEach, beforeAll, afterEach, and afterAll from being printed in the Text reporters.