### PR TITLE
Fix up tests for roblox-cli

### DIFF
--- a/test/runner.server.lua
+++ b/test/runner.server.lua
@@ -86,7 +86,7 @@ elseif isRobloxCli then
 	if errorMessage ~= nil then
 		print(errorMessage)
 	end
-	ProcessService:Exit(statusCode)
+	ProcessService:ExitAsync(statusCode)
 else
 	-- In Studio, we can just throw an error to get the user's attention
 

--- a/tests/Expectation.lua
+++ b/tests/Expectation.lua
@@ -87,9 +87,16 @@ return {
             expect:throw("foo")
         end)
 
+
         assert(not success, "should fail")
+        -- Make sure we state the expected error
         assert(
-            message:match("Expected function to throw an error containing \"foo\", but it threw: .+%.lua:%d+: oof"),
+            message:match("Expected function to throw an error containing \"foo\""),
+            ("Error message does not match:\n%s\n"):format(message)
+        )
+        -- Make sure we state the actual error
+        assert(
+            message:match(": oof"),
             ("Error message does not match:\n%s\n"):format(message)
         )
     end,
@@ -130,9 +137,14 @@ return {
         end)
 
         assert(not success, "should fail")
+        -- Make sure we state the expected error
         assert(
-            message:match("Expected function to never throw an error containing \"oof\", "
-                .. "but it threw: .+%.lua:%d+: foo%-oof"),
+            message:match("Expected function to never throw an error containing \"oof\""),
+            ("Error message does not match:\n%s\n"):format(message)
+        )
+        -- Make sure we state the actual error
+        assert(
+            message:match(": foo%-oof"),
             ("Error message does not match:\n%s\n"):format(message)
         )
     end,

--- a/tests/Expectation.lua
+++ b/tests/Expectation.lua
@@ -87,7 +87,6 @@ return {
             expect:throw("foo")
         end)
 
-
         assert(not success, "should fail")
         -- Make sure we state the expected error
         assert(


### PR DESCRIPTION
ProcessService:Exit has been removed in favor of ProcessService:ExitAsync

robloxcli does not have access to `.+%.lua:%d+`