### PR TITLE
Run code in the afterEach block after failure in an it block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # TestEZ Changelog
 
 ## Unreleased Changes
+* `afterEach` blocks now run their code after `it` blocks fail or error
 
 
 ## 0.4.0 (2020-10-02)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -135,6 +135,7 @@ afterEach(callback(context: table))
 ```
 
 Returns a function after each of the tests within its scope. This is useful if you want to cleanup some temporary state that is created by each test.
+It is always ran regardless of if the test failed or not.
 
 ```lua
 local DEFAULT_STATE = {

--- a/src/TestRunner.lua
+++ b/src/TestRunner.lua
@@ -113,18 +113,20 @@ function TestRunner.runPlanNode(session, planNode, lifecycleHooks)
 			end
 		end
 
-		do
-			local success, errorMessage = runCallback(childPlanNode.callback)
-			if not success then
-				return false, errorMessage
-			end
-		end
+		local testSuccess, testErrorMessage = runCallback(childPlanNode.callback)
 
 		for _, hook in ipairs(lifecycleHooks:getAfterEachHooks()) do
 			local success, errorMessage = runCallback(hook, "afterEach hook: ")
 			if not success then
+				if not testSuccess then
+					return false, testErrorMessage .. "\nWhile cleaning up the failed test another error was found:\n" .. errorMessage
+				end
 				return false, errorMessage
 			end
+		end
+
+		if not testSuccess then
+			return false, testErrorMessage
 		end
 
 		return true, nil

--- a/test/roblox-cli.sh
+++ b/test/roblox-cli.sh
@@ -15,4 +15,4 @@ else
 fi
 
 rojo build test-place.project.json -o TestPlace.rbxlx
-roblox-cli run --load.place TestPlace.rbxlx --assetFolder "$CONTENT"
+robloxdev-cli run --load.place TestPlace.rbxlx --assetFolder "$CONTENT"

--- a/test/roblox-cli.sh
+++ b/test/roblox-cli.sh
@@ -15,4 +15,4 @@ else
 fi
 
 rojo build test-place.project.json -o TestPlace.rbxlx
-robloxdev-cli run --load.place TestPlace.rbxlx --assetFolder "$CONTENT"
+roblox-cli run --load.place TestPlace.rbxlx --assetFolder "$CONTENT"

--- a/tests/e2e/afterEachAfterFailure/errorInAfterEachBlock/errorInAfterEachBlock.spec.lua
+++ b/tests/e2e/afterEachAfterFailure/errorInAfterEachBlock/errorInAfterEachBlock.spec.lua
@@ -1,6 +1,6 @@
 return function()
 	describe("When an error occurs in an afterEach block", function()
-		it("Should fail", function()
+		it("Should pass", function()
 			expect(true).to.equal(true)
 		end)
 

--- a/tests/e2e/afterEachAfterFailure/errorInAfterEachBlock/errorInAfterEachBlock.spec.lua
+++ b/tests/e2e/afterEachAfterFailure/errorInAfterEachBlock/errorInAfterEachBlock.spec.lua
@@ -1,0 +1,12 @@
+return function()
+	describe("When an error occurs in an afterEach block", function()
+		it("Should fail", function()
+			expect(true).to.equal(true)
+		end)
+
+		afterEach(function()
+			-- Cause a failure to be picked up by the test harness
+			error("afterEach threw an error as expected")
+		end)
+	end)
+end

--- a/tests/e2e/afterEachAfterFailure/errorInItBlock/errorInItBlock.spec.lua
+++ b/tests/e2e/afterEachAfterFailure/errorInItBlock/errorInItBlock.spec.lua
@@ -1,0 +1,12 @@
+return function()
+	describe("When an error occurs in an it block", function()
+		it("Should error", function()
+			error("Failure in it block")
+		end)
+
+		afterEach(function()
+			-- Cause an error to be picked up by the test harness
+			error("afterEach threw an error as expected")
+		end)
+	end)
+end

--- a/tests/e2e/afterEachAfterFailure/failureInItBlock/failureInItBlock.spec.lua
+++ b/tests/e2e/afterEachAfterFailure/failureInItBlock/failureInItBlock.spec.lua
@@ -1,0 +1,12 @@
+return function()
+	describe("When a failure occurs in an it block", function()
+		it("Should fail", function()
+			fail("Failure in it block")
+		end)
+
+		afterEach(function()
+			-- Cause an error to be picked up by the test harness
+			error("afterEach threw an error as expected")
+		end)
+	end)
+end

--- a/tests/e2e/init.lua
+++ b/tests/e2e/init.lua
@@ -14,6 +14,42 @@ return {
 		end)
 	end,
 
+	["run afterEach e2e with error in it block"] = function()
+		TestEZ.run(script:FindFirstChild("afterEachAfterFailure"):FindFirstChild("errorInItBlock"), function(results)
+			assert(#results.errors == 1, "Expected one error, got " .. tostring(#results.errors))
+
+			local afterEachError = string.find(results.errors[1], "afterEach threw an error as expected")
+			assert(afterEachError ~= nil, "Expected afterEach to be reached after it throws an error")
+
+			local cleaningUpError = string.find(results.errors[1], "While cleaning up the failed test another error was found")
+			assert(cleaningUpError ~= nil, "Expected 'While cleaning up...' msg to be shown when afterEach fails after it fails")
+		end)
+	end,
+
+	["run afterEach e2e with failure in it block"] = function()
+		TestEZ.run(script:FindFirstChild("afterEachAfterFailure"):FindFirstChild("failureInItBlock"), function(results)
+			assert(#results.errors == 1, "Expected one error, got " .. tostring(#results.errors))
+
+			local afterEachError = string.find(results.errors[1], "afterEach threw an error as expected")
+			assert(afterEachError ~= nil, "Expected afterEach to be reached after it throws an error")
+
+			local cleaningUpError = string.find(results.errors[1], "While cleaning up the failed test another error was found")
+			assert(cleaningUpError ~= nil, "Expected 'While cleaning up...' msg to be shown when afterEach fails after it fails")
+		end)
+	end,
+
+	["run afterEach e2e with failure in afterEach block"] = function()
+		TestEZ.run(script:FindFirstChild("afterEachAfterFailure"):FindFirstChild("errorInAfterEachBlock"), function(results)
+			assert(#results.errors == 1, "Expected one error, got " .. tostring(#results.errors))
+
+			local afterEachError = string.find(results.errors[1], "afterEach threw an error as expected")
+			assert(afterEachError ~= nil, "Expected afterEach to be reached after it throws an error")
+
+			local cleaningUpError = string.find(results.errors[1], "While cleaning up the failed test another error was found")
+			assert(cleaningUpError == nil, "Expected 'While cleaning up...' msg to not be shown when only afterEach fails")
+		end)
+	end,
+
 	["run lifecycle e2e w/ filter for describe block"] = function()
 		TestEZ.TestBootstrap:run({
 			script:FindFirstChild("lifecycle"):FindFirstChild("testNameFilterDescribeBlock"),


### PR DESCRIPTION
Modifies the TestRunner to continue running the tests after a failure in the it block.  Any errors reported after the it block are appended to the error message with the line "While cleaning up the failed test another error was found" separating them.

- [x] Code Style: Match the existing code! (I tried to follow the style.  If there are changes I should make let me know!)
- [x] Changelog: Add an entry to CHANGELOG.md
- [x] Luacheck: Run Luacheck on your code, no warnings allowed!
- [x] Tests: They all need to pass!


Fixes #148 and fixes #127 