### PR TITLE
Update luacheck-related CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
       with:
         submodules: true
 
-    - uses: leafo/gh-actions-lua@v5
+    - uses: leafo/gh-actions-lua@v8
       with:
         luaVersion: "5.1"
 
-    - uses: leafo/gh-actions-luarocks@v2
+    - uses: leafo/gh-actions-luarocks@v4
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Fixes an impending issue where the old actions would use no-longer-supported GitHub Actions api members.