### PR TITLE
Set time to os.clock in test environment

### DIFF
--- a/src/TestPlan.lua
+++ b/src/TestPlan.lua
@@ -5,6 +5,9 @@
 	TestPlan objects are produced by TestPlanner.
 ]]
 
+local RunService = game:GetService("RunService")
+local IS_NOT_RUNNING = not RunService:IsRunning()
+
 local TestEnum = require(script.Parent.TestEnum)
 local Expectation = require(script.Parent.Expectation)
 
@@ -104,6 +107,12 @@ local function newEnvironment(currentNode, extraEnvironment)
 	env.xit = env.itSKIP
 	env.fdescribe = env.describeFOCUS
 	env.xdescribe = env.describeSKIP
+
+	-- Most prominent when using run-in-roblox, while running tests without entering run mode,
+	-- time(), will always equal zero due to the server not running.
+	if IS_NOT_RUNNING then
+		env.time = os.clock
+	end
 
 	env.expect = setmetatable({
 		extend = function(...)


### PR DESCRIPTION
I'm wondering if this is controversial, but I've recently encountered issues where calling time(), without entering run mode, always equals zero due to the server never starting. This is definitely behavior that isn't relied upon and it really helps when using run-in-Roblox, especially associated with continuous integration.
Yes, it might make sense more to just use os.clock() in the first place, but according to a devforum announcement, os.clock() should be used for performance benchmarks, whereas time() should be used for everything else (besides obviously compared to something like os.time()).