### PR TITLE
Allow deploy-docs to support workflow_dispatch

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,6 +1,7 @@
 name: Deploy docs
 
 on:
+  workflow_dispatch:
   push:
     tags: ["*"]
 


### PR DESCRIPTION
To manually run the deploy-docs action, we'll have to make sure it can run with the `workflow_dispatch` trigger.