### PR TITLE
Add Wally manifest file

### DIFF
--- a/wally.toml
+++ b/wally.toml
@@ -1,0 +1,8 @@
+[package]
+name = "roblox/testez"
+version = "0.4.1"
+license = "Apache2"
+registry = "https://github.com/UpliftGames/wally-index"
+realm = "shared"
+
+[dependencies]


### PR DESCRIPTION
This PR adds a [Wally](https://github.com/UpliftGames/wally) manifest file to the repository for the latest release of TestEZ.

Wally is a package manager for Roblox developed at Uplift Games. It's part of our initiative to create an open ecosystem of shared, accessible code and high quality tooling for Roblox developers.

With Wally, adding TestEZ to an existing Roblox project is very easy:
```toml
[package]
name = "magnalite/lets-use-testez"
version = "0.1.0"
registry = "https://github.com/UpliftGames/wally-index"
realm = "shared"

[dependencies]
TestEZ = "roblox/testez@0.4.1"
```
```
$ wally install
[INFO ] Updating package index...
[INFO ] Downloading roblox/testez@0.4.1...
```

Our public Wally registry is now accepting packages from anyone who would like to publish, similar to [crates.io](https://crates.io/). We would love to see you publish great open source packages like TestEZ! We've found a large portion of packages already depend on TestEZ so we've made it available on Wally as a convenience due to this demand, however it's our ambition for us to work together on supporting the open source Roblox ecosystem.

Adding this `wally.toml` manifest file is the first step in this direction, and makes publishing TestEZ to Wally easy!