### PR TITLE
Update GHA non-cached third party actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
       with:
         submodules: true
 
-    - uses: leafo/gh-actions-lua@v8
+    - uses: roblox-actionscache/leafo-gh-actions-lua@v8
       with:
         luaVersion: "5.1"
 
-    - uses: leafo/gh-actions-luarocks@v4
+    - uses: roblox-actionscache/leafo-gh-actions-luarocks@v4
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@1.16
+        uses: roblox-actionscache/mhausenblas-mkdocs-deploy-gh-pages@1.16
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REQUIREMENTS: 'docs/requirements.txt'


### PR DESCRIPTION
This batch change updates several non-cached GHA third party actions to use Roblox-ActionsCache.

[_Created by Sourcegraph batch change `dpille/update-gha-non-cached-actions-d-pille`._](https://sourcegraph.rbx.com/users/dpille/batch-changes/update-gha-non-cached-actions-d-pille)