### PR TITLE
Update setup-foreman action path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Setup Rust toolchain
       run: rustup default ${{ matrix.rust_version }}
 
-    - uses: rojo-rbx/setup-foreman@v1
+    - uses: Roblox/setup-foreman@v1
       with:
         version: "^0.6.0"
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         submodules: true
 
-    - uses: rojo-rbx/setup-foreman@v1
+    - uses: Roblox/setup-foreman@v1
       with:
         version: "^0.6.0"
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -38,7 +38,7 @@ jobs:
     - name: Install Rust
       run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
-    - uses: rojo-rbx/setup-foreman@v1
+    - uses: Roblox/setup-foreman@v1
       with:
         version: "^0.6.0"
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -62,7 +62,7 @@ jobs:
       with:
         submodules: true
 
-    - uses: rojo-rbx/setup-foreman@v1
+    - uses: Roblox/setup-foreman@v1
       with:
         version: "^0.6.0"
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This batch change updates the reference to the `setup-foreman` action to use the current location of the action in the Roblox org. This should be a no-op, or may fix currently-broken CI.
Please refer to [confluence](https://confluence.rbx.com/display/ENGEFF/Removal+of+grandfathered+3rd-party+GitHub+Actions) for more information.

[_Created by Sourcegraph batch change `pdoyle/migrate-setup-foreman-action`._](https://sourcegraph.rbx.com/users/pdoyle/batch-changes/migrate-setup-foreman-action)