### PR TITLE
APT-606 - Change Foreman To Install Internal Mirrors Instead Of External Tools APT-578 Upgrade setup-foreman to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Setup Rust toolchain
       run: rustup default ${{ matrix.rust_version }}
 
-    - uses: Roblox/setup-foreman@v1
+    - uses: Roblox/setup-foreman@v3
       with:
         version: "^0.6.0"
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         submodules: true
 
-    - uses: Roblox/setup-foreman@v1
+    - uses: Roblox/setup-foreman@v3
       with:
         version: "^0.6.0"
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -38,7 +38,7 @@ jobs:
     - name: Install Rust
       run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
-    - uses: Roblox/setup-foreman@v1
+    - uses: Roblox/setup-foreman@v3
       with:
         version: "^0.6.0"
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -62,7 +62,7 @@ jobs:
       with:
         submodules: true
 
-    - uses: Roblox/setup-foreman@v1
+    - uses: Roblox/setup-foreman@v3
       with:
         version: "^0.6.0"
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We should use setup-foreman v3 to enforce that tools installed by Foreman in CI come from Roblox repos

[_Created by Sourcegraph batch change `afujiwara/APT-578-upgrade-all-setup-foreman-actions-in-ci`._](https://sourcegraph.rbx.com/users/afujiwara/batch-changes/APT-578-upgrade-all-setup-foreman-actions-in-ci)